### PR TITLE
fixing postgres composition string transform

### DIFF
--- a/database/postgres/composition.yaml
+++ b/database/postgres/composition.yaml
@@ -43,7 +43,8 @@ spec:
         toFieldPath: "spec.writeConnectionSecretToRef.name"
         transforms:
           - type: string
-            fmt: "%s-postgresql"
+            string:
+              fmt: "%s-postgresql"
       - fromFieldPath: "spec.parameters.storageGB"
         toFieldPath: "spec.forProvider.allocatedStorage"
       - fromFieldPath: "spec.parameters.networkRef.name"


### PR DESCRIPTION
verified `RDSInstance` is being created now:

Fixes: https://github.com/upbound/platform-ref-aws/issues/4

![image](https://user-images.githubusercontent.com/284840/95528570-4e157580-098d-11eb-9bea-24a019df6a25.png)

```
k get managed
NAME                                                       READY   SYNCED   STATE       ENGINE     VERSION   AGE
rdsinstance.database.aws.crossplane.io/my-db-58wqx-blt4h   True    True     available   postgres   9.6.18    15m

NAME                                                         READY   SYNCED   AGE
dbsubnetgroup.database.aws.crossplane.io/my-db-58wqx-jnkcn   True    True     15m

NAME                                                        READY   SYNCED   ID                      VPC                     AGE
internetgateway.ec2.aws.crossplane.io/network-b246k-c52k2   True    True     igw-0a6fa6b34506f1186   vpc-0c4a8e9a518ae35f1   15m

NAME                                            READY   SYNCED   ID                      CIDR             AGE
vpc.ec2.aws.crossplane.io/network-b246k-s4kmm   True    True     vpc-0c4a8e9a518ae35f1   192.168.0.0/16   15m

NAME                                                      READY   SYNCED   ID                     VPC                     AGE
securitygroup.ec2.aws.crossplane.io/network-b246k-k58q5   True    True     sg-095bb0ef198a2d848   vpc-0c4a8e9a518ae35f1   15m

NAME                                               READY   SYNCED   ID                         VPC                     CIDR               AGE
subnet.ec2.aws.crossplane.io/network-b246k-k5mmm   True    True     subnet-0e22bc9a2b30c4f66   vpc-0c4a8e9a518ae35f1   192.168.0.0/18     15m
subnet.ec2.aws.crossplane.io/network-b246k-sdns8   True    True     subnet-0698789e731398109   vpc-0c4a8e9a518ae35f1   192.168.64.0/18    15m
subnet.ec2.aws.crossplane.io/network-b246k-z4824   True    True     subnet-03e9c9f0e6f3647f6   vpc-0c4a8e9a518ae35f1   192.168.128.0/18   15m
subnet.ec2.aws.crossplane.io/network-b246k-z7krf   True    True     subnet-0e4a21cc785bcd16b   vpc-0c4a8e9a518ae35f1   192.168.192.0/18   15m

NAME                                                   READY   SYNCED   ID                      VPC                     AGE
routetable.ec2.aws.crossplane.io/network-b246k-v5k7j   True    True     rtb-078b0b29850e29fff   vpc-0c4a8e9a518ae35f1   15m
```