### PR TITLE
make db connectivity private by default

### DIFF
--- a/database/postgres/composition.yaml
+++ b/database/postgres/composition.yaml
@@ -41,7 +41,7 @@ spec:
             engine: postgres
             engineVersion: "9.6"
             skipFinalSnapshotBeforeDeletion: true
-            publiclyAccessible: true
+            publiclyAccessible: false
           writeConnectionSecretToRef:
             namespace: crossplane-system
           reclaimPolicy: Delete


### PR DESCRIPTION
Resolves #10 - RDSInstance should not be publicly accessible

Just sets the default to false, building on the public | private [connectivity options added previously](https://github.com/upbound/platform-ref-aws/commit/425f5561daf7d4e7fefbb7b33fd8be08dcc867a7#diff-e616a135f02a77a09127548004ec87c1e8e3fe26a332f6f039ed8409b8fd2887R24).

Verified in multiple environments.

Signed-off-by: Phil Prasek <prasek@gmail.com>