### PR TITLE
update cluster definitions and compositions to successfully deploy EKS

### DIFF
--- a/cluster/composition.yaml
+++ b/cluster/composition.yaml
@@ -9,35 +9,35 @@ spec:
     apiVersion: aws.platformref.crossplane.io/v1alpha1
     kind: CompositeCluster
   resources:
-  - base:
-      apiVersion: aws.platformref.crossplane.io/v1alpha1
-      kind: EKS
-    patches:
-    - fromFieldPath: spec.name
-      toFieldPath: metadata.annotations[crossplane.io/external-name]
-    - fromFieldPath: metadata.uid
-      toFieldPath: spec.writeConnectionSecretToRef.name
-      transforms:
-      - type: string
-        string:
-          fmt: "%s-eks"
-    - fromFieldPath: spec.parameters.nodes.count
-      toFieldPath: spec.parameters.nodes.count
-    - fromFieldPath: spec.parameters.nodes.size
-      toFieldPath: spec.parameters.nodes.size
-    - fromFieldPath: spec.parameters.networkRef.name
-      toFieldPath: spec.parameters.networkRef.name
-  - base:
-      apiVersion: aws.platformref.crossplane.io/v1alpha1
-      kind: Services
-    patches:
-    - fromFieldPath: metadata.uid
-      toFieldPath: spec.providerConfigRef.name
-      transforms:
-      - type: string
-        string:
-          fmt: "%s-eks"
-    - fromFieldPath: spec.parameters.services.operators.prometheus.image
-      toFieldPath: spec.operators.prometheus.image
-    - fromFieldPath: spec.parameters.services.operators.prometheus.tag
-      toFieldPath: spec.operators.prometheus.tag
+    - base:
+        apiVersion: aws.platformref.crossplane.io/v1alpha1
+        kind: EKS
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: spec.name
+        - fromFieldPath: spec.name
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - fromFieldPath: metadata.uid
+          toFieldPath: spec.writeConnectionSecretToRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-eks"
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - fromFieldPath: spec.parameters.nodes.count
+          toFieldPath: spec.parameters.nodes.count
+        - fromFieldPath: spec.parameters.nodes.size
+          toFieldPath: spec.parameters.nodes.size
+        - fromFieldPath: spec.parameters.networkRef.name
+          toFieldPath: spec.parameters.networkRef.name
+    - base:
+        apiVersion: aws.platformref.crossplane.io/v1alpha1
+        kind: Services
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: spec.providerConfigRef.name
+        - fromFieldPath: spec.parameters.services.operators.prometheus.image
+          toFieldPath: spec.operators.prometheus.image
+        - fromFieldPath: spec.parameters.services.operators.prometheus.tag
+          toFieldPath: spec.operators.prometheus.tag

--- a/cluster/definition.yaml
+++ b/cluster/definition.yaml
@@ -99,7 +99,7 @@ spec:
                     description: Cluster node configuration parameters.
                     properties:
                       count:
-                        type: int
+                        type: integer
                         description: Desired node count, from 1 to 100.
                       size:
                         type: string
@@ -137,8 +137,8 @@ spec:
                       name:
                         type: string
                         description: Name of the Network object this ref points to.
-                      required:
-                      - name
+                    required:
+                    - name
                 required:
                 - nodes
                 - networkRef

--- a/cluster/eks/composition.yaml
+++ b/cluster/eks/composition.yaml
@@ -11,196 +11,180 @@ spec:
     apiVersion: aws.platformref.crossplane.io/v1alpha1
     kind: EKS
   resources:
-  - base:
-      apiVersion: identity.aws.crossplane.io/v1beta1
-      kind: IAMRole
-      metadata:
-        labels:
-          role: controlplane
-      spec:
-        forProvider:
-          assumeRolePolicyDocument: |
-            {
-              "Version": "2012-10-17",
-              "Statement": [
-                  {
-                      "Effect": "Allow",
-                      "Principal": {
-                          "Service": [
-                              "eks.amazonaws.com"
-                          ]
-                      },
-                      "Action": [
-                          "sts:AssumeRole"
-                      ]
-                  }
-              ]
-            }
-  - base:
-      apiVersion: identity.aws.crossplane.io/v1beta1
-      kind: IAMRolePolicyAttachment
-      spec:
-        forProvider:
-          policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-          roleNameSelector:
-            matchControllerRef: true
-            matchLabels:
-              role: controlplane
-  - base:
-      apiVersion: eks.aws.crossplane.io/v1beta1
-      kind: Cluster
-      spec:
-        forProvider:
-          roleArnSelector:
-            matchControllerRef: true
-            matchLabels:
-              role: controlplane
-          resourcesVpcConfig:
-            endpointPrivateAccess: true
-            endpointPublicAccess: false
-          version: "1.16"
-    patches:
-    - fromFieldPath: metadata.annotations[crossplane.io/external-name]
-      toFieldPath: metadata.annotations[crossplane.io/external-name]
-    - fromFieldPath: metadata.uid
-      toFieldPath: spec.writeConnectionSecretToRef.name
-      transforms:
-      - type: string
-        string:
-          fmt: "%s-eks-controlplane"
-    - fromFieldPath: "spec.parameters.networkRef.name"
-      toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
-    connectionDetails:
-    - fromConnectionSecretKey: kubeconfig
-  - base:
-      apiVersion: identity.aws.crossplane.io/v1beta1
-      kind: IAMRole
-      labels:
-        role: nodegroup
-      spec:
-        forProvider:
-          assumeRolePolicyDocument: |
-            {
-              "Version": "2012-10-17",
-              "Statement": [
-                  {
-                      "Effect": "Allow",
-                      "Principal": {
-                          "Service": [
-                              "ec2.amazonaws.com"
-                          ]
-                      },
-                      "Action": [
-                          "sts:AssumeRole"
-                      ]
-                  }
-              ]
-            }
-  - base:
-      apiVersion: identity.aws.crossplane.io/v1beta1
-      kind: IAMRolePolicyAttachment
-      spec:
-        forProvider:
-          policyArn: arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
-          roleNameSelector:
-            matchControllerRef: true
-            matchLabels:
-              role: nodegroup
-  - base:
-      apiVersion: identity.aws.crossplane.io/v1beta1
-      kind: IAMRolePolicyAttachment
-      spec:
-        forProvider:
-          policyArn: arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-          roleNameSelector:
-            matchControllerRef: true
-            matchLabels:
-              role: nodegroup
-  - base:
-      apiVersion: identity.aws.crossplane.io/v1beta1
-      kind: IAMRolePolicyAttachment
-      spec:
-        forProvider:
-          policyArn: arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
-          roleNameSelector:
-            matchControllerRef: true
-            matchLabels:
-              role: nodegroup
-  - base:
-      apiVersion: eks.aws.crossplane.io/v1alpha1
-      kind: NodeGroup
-      spec:
-        forProvider:
-          clusterNameSelector:
-            matchControllerRef: true
-          nodeRoleArnSelector:
-            matchControllerRef: true
-            matchLabels:
-              role: nodegroup
-          subnetSelector:
-            matchLabels:
-              access: private
-          scalingConfig:
-            minSize: 1
-            maxSize: 100
-            desiredSize: 1
-          instanceTypes:
-          - t3.medium
-    patches:
-      - fromFieldPath: metadata.annotations[crossplane.io/external-name]
-        toFieldPath: metadata.annotations[crossplane.io/external-name]
-      - fromFieldPath: "spec.parameters.nodes.count"
-        toFieldPath: "spec.forProvider.scalingConfig.desiredSize"
-      - fromFieldPath: "spec.parameters.nodes.size"
-        toFieldPath: "spec.forProvider.instanceTypes[0]"
-        transforms:
-        - type: map
-          map:
-            small: t3.small
-            medium: t3.medium
-            large: t3.large
-      - fromFieldPath: "spec.parameters.networkRef.name"
-        toFieldPath: spec.forProvider.subnetSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
-  - base:
-      apiVersion: eks.aws.crossplane.io/v1alpha1
-      kind: NodeGroup
-      spec:
-        forProvider:
-          clusterNameSelector:
-            matchControllerRef: true
-          nodeRoleArnSelector:
-            matchControllerRef: true
-            matchLabels:
-              role: nodegroup
-          subnetSelector:
-            matchLabels:
-              access: private
-          scalingConfig:
-            minSize: 1
-            maxSize: 100
-            desiredSize: 1
-          instanceTypes:
-          - t3.medium
-    patches:
-      - fromFieldPath: metadata.annotations[crossplane.io/external-name]
-        toFieldPath: metadata.annotations[crossplane.io/external-name]
-      - fromFieldPath: "spec.parameters.nodes.count"
-        toFieldPath: "spec.forProvider.scalingConfig.desiredSize"
-      - fromFieldPath: "spec.parameters.nodes.size"
-        toFieldPath: "spec.forProvider.instanceTypes[0]"
-        transforms:
-        - type: map
-          map:
-            small: t3.small
-            medium: t3.medium
-            large: t3.large
-      - fromFieldPath: "spec.parameters.networkRef.name"
-        toFieldPath: spec.forProvider.subnetSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
-  - base:
-      apiVersion: kubernetes.crossplane.io/v1alpha1
-      kind: ProviderConfig
-    patches:
-    - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-      toFieldPath: spec.credentialsSecretRef.namespace
-    - fromFieldPath: spec.writeConnectionSecretToRef.name
-      toFieldPath: spec.credentialsSecretRef.name
+    - base:
+        apiVersion: identity.aws.crossplane.io/v1beta1
+        kind: IAMRole
+        metadata:
+          labels:
+            role: controlplane
+        spec:
+          forProvider:
+            assumeRolePolicyDocument: |
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": [
+                                "eks.amazonaws.com"
+                            ]
+                        },
+                        "Action": [
+                            "sts:AssumeRole"
+                        ]
+                    }
+                ]
+              }
+    - base:
+        apiVersion: identity.aws.crossplane.io/v1beta1
+        kind: IAMRolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: controlplane
+    - base:
+        apiVersion: eks.aws.crossplane.io/v1beta1
+        kind: Cluster
+        spec:
+          forProvider:
+            region: us-west-2
+            roleArnSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: controlplane
+            resourcesVpcConfig:
+              endpointPrivateAccess: true
+              endpointPublicAccess: false
+            version: "1.16"
+      patches:
+        - fromFieldPath: metadata.annotations[crossplane.io/external-name]
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - fromFieldPath: metadata.uid
+          toFieldPath: spec.writeConnectionSecretToRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-ekscluster"
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - fromFieldPath: "spec.parameters.networkRef.name"
+          toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
+      connectionDetails:
+        - fromConnectionSecretKey: kubeconfig
+    - base:
+        apiVersion: identity.aws.crossplane.io/v1beta1
+        kind: IAMRole
+        metadata:
+          labels:
+            role: nodegroup
+        spec:
+          forProvider:
+            assumeRolePolicyDocument: |
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": [
+                                "ec2.amazonaws.com"
+                            ]
+                        },
+                        "Action": [
+                            "sts:AssumeRole"
+                        ]
+                    }
+                ]
+              }
+    - base:
+        apiVersion: identity.aws.crossplane.io/v1beta1
+        kind: IAMRolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: nodegroup
+    - base:
+        apiVersion: identity.aws.crossplane.io/v1beta1
+        kind: IAMRolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: nodegroup
+    - base:
+        apiVersion: identity.aws.crossplane.io/v1beta1
+        kind: IAMRolePolicyAttachment
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+            roleNameSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: nodegroup
+    - base:
+        apiVersion: eks.aws.crossplane.io/v1alpha1
+        kind: NodeGroup
+        spec:
+          forProvider:
+            region: us-west-2
+            clusterNameSelector:
+              matchControllerRef: true
+            nodeRoleSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: nodegroup
+            subnetSelector:
+              matchLabels:
+                access: public
+            scalingConfig:
+              minSize: 1
+              maxSize: 100
+              desiredSize: 1
+            instanceTypes:
+              - t3.medium
+      patches:
+        - fromFieldPath: metadata.annotations[crossplane.io/external-name]
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - fromFieldPath: "spec.parameters.nodes.count"
+          toFieldPath: "spec.forProvider.scalingConfig.desiredSize"
+        - fromFieldPath: "spec.parameters.nodes.size"
+          toFieldPath: "spec.forProvider.instanceTypes[0]"
+          transforms:
+            - type: map
+              map:
+                small: t3.small
+                medium: t3.medium
+                large: t3.large
+        - fromFieldPath: "spec.parameters.networkRef.name"
+          toFieldPath: spec.forProvider.subnetSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
+    - base:
+        apiVersion: helm.crossplane.io/v1alpha1
+        kind: ProviderConfig
+        spec:
+          credentials:
+            source: Secret
+            secretRef:
+              namespace: crossplane-system
+              key: kubeconfig
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: metadata.name
+        # This ProviderConfig uses the above EKS cluster's connection secret as
+        # its credentials secret.
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: spec.credentials.secretRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-ekscluster"
+      readinessChecks:
+        - type: None

--- a/cluster/eks/definition.yaml
+++ b/cluster/eks/definition.yaml
@@ -18,33 +18,38 @@ spec:
           spec:
             type: object
             properties:
+              name:
+                type: string
+                description: Name of this Cluster that other objects will use to refer to it.
               parameters:
                 type: object
                 description: EKS configuration parameters.
-                nodes:
-                  type: object
-                  description: EKS node configuration parameters.
-                  count:
-                    type: int
-                    description: Desired node count, from 1 to 100.
-                  size:
-                    type: string
-                    description: Size of node.
-                    enum:
-                    - small
-                    - medium
-                    - large
-                  required:
-                  - count
-                  - size
-                networkRef:
-                  type: object
-                  description: "A reference to the Network object that this postgres should be
-                  connected to."
-                  properties:
-                    name:
-                      type: string
-                      description: Name of the Network object this ref points to.
+                properties:
+                  nodes:
+                    type: object
+                    description: EKS node configuration parameters.
+                    properties:
+                      count:
+                        type: integer
+                        description: Desired node count, from 1 to 100.
+                      size:
+                        type: string
+                        description: Size of node.
+                        enum:
+                        - small
+                        - medium
+                        - large
+                    required:
+                    - count
+                    - size
+                  networkRef:
+                    type: object
+                    description: "A reference to the Network object that this postgres should be
+                    connected to."
+                    properties:
+                      name:
+                        type: string
+                        description: Name of the Network object this ref points to.
                     required:
                     - name
                 required:

--- a/cluster/services/composition.yaml
+++ b/cluster/services/composition.yaml
@@ -12,33 +12,33 @@ spec:
     apiVersion: aws.platformref.crossplane.io/v1alpha1
     kind: Services
   resources:
-  - base:
-      apiVersion: helm.crossplane.io/v1alpha1
-      kind: Release
-      spec:
-        forProvider:
-          namespace: operators
-          chart:
-            # from https://github.com/prometheus-community/helm-charts
-            name: prometheus-operator
-            repository: https://prometheus-community.github.io/helm-charts
-          # Note that default values are overridden by the patches below.
-          set:
-          - name: image.repository
-            value: prom/prometheus
-          - name: image.tag
-            value: "v2.20.1"
-    patches:
-    # All Helm releases derive their labels and annotations from the XR.
-    - fromFieldPath: metadata.labels
-      toFieldPath: metadata.labels
-    - fromFieldPath: metadata.annotations
-      toFieldPath: metadata.annotations
-    # All Helm releases derive the ProviderConfig to use from the XR.
-    - fromFieldPath: spec.providerConfigRef.name
-      toFieldPath: spec.providerConfigRef.name
-    # Derive the Prometheus operator image and tag from the XR.
-    - fromFieldPath: spec.operators.prometheus.image
-      toFieldPath: spec.forProvider.set[0].value
-    - fromFieldPath: spec.operators.prometheus.tag
-      toFieldPath: spec.forProvider.set[1].value
+    - base:
+        apiVersion: helm.crossplane.io/v1alpha1
+        kind: Release
+        spec:
+          forProvider:
+            namespace: operators
+            chart:
+              # from https://github.com/prometheus-community/helm-charts
+              name: prometheus-operator
+              repository: https://prometheus-community.github.io/helm-charts
+            # Note that default values are overridden by the patches below.
+            set:
+              - name: image.repository
+                value: prom/prometheus
+              - name: image.tag
+                value: "v2.20.1"
+      patches:
+        # All Helm releases derive their labels and annotations from the XR.
+        - fromFieldPath: metadata.labels
+          toFieldPath: metadata.labels
+        - fromFieldPath: metadata.annotations
+          toFieldPath: metadata.annotations
+        # All Helm releases derive the ProviderConfig to use from the XR.
+        - fromFieldPath: spec.providerConfigRef.name
+          toFieldPath: spec.providerConfigRef.name
+        # Derive the Prometheus operator image and tag from the XR.
+        - fromFieldPath: spec.operators.prometheus.image
+          toFieldPath: spec.forProvider.set[0].value
+        - fromFieldPath: spec.operators.prometheus.tag
+          toFieldPath: spec.forProvider.set[1].value

--- a/cluster/services/definition.yaml
+++ b/cluster/services/definition.yaml
@@ -33,11 +33,12 @@ spec:
                 type: object
                 description: "A reference to the ProviderConfig of the cluster that services should
                 be deployed to."
-                name:
-                  type: string
-                  description: "Name of the Kubernetes provider configuration.
-                    This will typically be the name of the cluster with a
-                    five character suffix appended."
+                properties:
+                  name:
+                    type: string
+                    description: "Name of the Kubernetes provider configuration.
+                      This will typically be the name of the cluster with a
+                      five character suffix appended."
                 required:
                 - name
             required:

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -1,0 +1,19 @@
+apiVersion: aws.platformref.crossplane.io/v1alpha1
+kind: Cluster
+metadata:
+  name: platform-ref-aws-cluster
+spec:
+  name: platform-ref-aws-cluster
+  parameters:
+    nodes:
+      count: 3
+      size: small
+    services:
+      operators:
+        prometheus:
+          image: prom/prometheus
+          tag: v2.20.1
+    networkRef:
+      name: network
+  writeConnectionSecretToRef:
+    name: platform-ref-aws-cluster


### PR DESCRIPTION
This PR contains a number of fixes to successfully deploy EKS with the new `examples/cluster.yaml` manifest (also included in this PR).

Note that I am using a VS Code plugin for yaml now so there are some whitespace only (indenting) changes that were done automatically.

Highlights:

* use proper field for NodeGroup `nodeRoleSelector` field
* use public subnets in NodeGroup's subnet selector
* set IAMRole labels correctly (under metadata, not a top level field)
* update multiple crdSpecTemplates to have proper syntax, where all fields of an object are under a `properties` parent
* generate the providerconfig.helm.crossplane.io object that is needed for the services helm release object