### PR TITLE
EKS services fixes and readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cp kubectl-crossplane /usr/local/bin
 
 ```console
 PROVIDER_AWS=crossplane/provider-aws:v0.12.0
-PROVIDER_HELM=crossplane/provider-helm:v0.3.0
+PROVIDER_HELM=crossplane/provider-helm:v0.3.5
 
 kubectl crossplane install provider ${PROVIDER_AWS}
 kubectl crossplane install provider ${PROVIDER_HELM}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # AWS Reference Platform for Kubernetes + Data Services
+
 This repository contains a reference AWS Platform
 [Configuration](https://crossplane.io/docs/v0.13/getting-started/package-infrastructure.html)
 for use as a starting point in [Upbound Cloud](https://upbound.io) to build,
@@ -12,23 +13,25 @@ deployments can securely connect to the infrastructure they need using secrets
 distributed directly to the app namespace.
 
 ## Contents
- * [Upbound Cloud](#upbound-cloud)
- * [Build Your Own Internal Cloud Platform](#build-your-own-internal-cloud-platform)
- * [Quick Start](#quick-start)
-   * [Platform Ops/SRE: Run your own internal cloud platform](#platform-opssre-run-your-own-internal-cloud-platform)
-   * [App Dev/Ops: Consume the infrastructure you need using kubectl](#app-devops-consume-the-infrastructure-you-need-using-kubectl)
- * [APIs in this Configuration](#apis-in-this-configuration)
- * [Customize for your Organization](#customize-for-your-organization)
- * [What's Next](#whats-next)
- * [Learn More](#learn-more)
- * [Local Dev Guide](#local-dev-guide)
+
+* [Upbound Cloud](#upbound-cloud)
+* [Build Your Own Internal Cloud Platform](#build-your-own-internal-cloud-platform)
+* [Quick Start](#quick-start)
+* [Platform Ops/SRE: Run your own internal cloud platform](#platform-opssre-run-your-own-internal-cloud-platform)
+  * [App Dev/Ops: Consume the infrastructure you need using kubectl](#app-devops-consume-the-infrastructure-you-need-using-kubectl)
+  * [APIs in this Configuration](#apis-in-this-configuration)
+* [Customize for your Organization](#customize-for-your-organization)
+* [What's Next](#whats-next)
+* [Learn More](#learn-more)
+* [Local Dev Guide](#local-dev-guide)
 
 ## Upbound Cloud
+
 **New Reference Platform support launching Nov 10th 2020!**
 
 ![Upbound Overview](docs/media/upbound.png)
 
-What if you could elimiate infrastructure bottlenecks, security pitfalls, and
+What if you could eliminate infrastructure bottlenecks, security pitfalls, and
 deliver apps faster by providing your teams with self-service APIs that
 encapsulate your best practices and security policies, so they can quickly
 provision the infrastructure they need using a custom cloud console, `kubectl`,
@@ -43,16 +46,18 @@ they need using vetted infrastructure configurations that meet the standards
 of your organization.
 
 ## Build Your Own Internal Cloud Platform
+
 App teams can provision the infrastructure they need with a single YAML file
-alongside `Deployments` and `Services` using existing tools and worklflows
+alongside `Deployments` and `Services` using existing tools and workflows
 including tools like `kubectl` and Flux to consume your platform's self-service
 APIs.
 
 The Platform `Configuration` defines the self-service APIs and
 classes-of-service for each API:
- - `CompositeResourceDefinitions` (XRDs) define the platform's self-service
+
+* `CompositeResourceDefinitions` (XRDs) define the platform's self-service
    APIs - e.g. `CompositePostgreSQLInstance`.
- - `Compositions` offer the classes-of-service supported for each self-service
+* `Compositions` offer the classes-of-service supported for each self-service
    API - e.g. `Standard`, `Performance`, `Replicated`.
 
 ![Upbound Overview](docs/media/compose.png)
@@ -64,31 +69,40 @@ Learn more about `Composition` in the [Crossplane
 Docs](https://crossplane.github.io/docs/v0.13/getting-started/compose-infrastructure.html).
 
 ## Quick Start
+
 ### Platform Ops/SRE: Run your own internal cloud platform
+
 #### Create a free account in Upbound Cloud
+
 1. Sign up for [Upbound Cloud](https://cloud.upbound.io/register).
 1. Create an `Organization` for your teams.
 
 #### Create a Platform instance in Upbound Cloud
+
 1. Create a `Platform` in Upbound Cloud (e.g. dev, staging, or prod).
 1. Connect `kubectl` to your `Platform` instance.
 
 #### Install the Crossplane kubectl extension (for convenience)
-```
+
+```console
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
 cp kubectl-crossplane /usr/local/bin
 ```
 
-#### Install the AWS Provider into your Platform
-```
-PROVIDER=crossplane/provider-aws:v0.12.0
+#### Install Providers into your Platform
 
-kubectl crossplane install provider ${PROVIDER}
+```console
+PROVIDER_AWS=crossplane/provider-aws:v0.12.0
+PROVIDER_HELM=crossplane/provider-helm:v0.3.0
+
+kubectl crossplane install provider ${PROVIDER_AWS}
+kubectl crossplane install provider ${PROVIDER_HELM}
 kubectl get pkg
 ```
 
 Create `ProviderConfig` and `Secret`
-```
+
+```console
 AWS_PROFILE=default && echo -e "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $AWS_PROFILE)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $AWS_PROFILE)" > creds.conf
 
 kubectl create secret generic aws-creds -n crossplane-system --from-file=key=./creds.conf
@@ -96,7 +110,8 @@ kubectl apply -f examples/aws-default-provider.yaml
 ```
 
 #### Install the Platform Configuration
-```
+
+```console
 PLATFORM_CONFIG=registry.upbound.io/upbound/platform-ref-aws:v0.0.1
 
 kubectl crossplane install configuration ${PLATFORM_CONFIG}
@@ -104,110 +119,130 @@ kubectl get pkg
 ```
 
 #### Create Network Fabric
-```
+
+```console
 kubectl apply -f examples/network.yaml
 ```
 
 Verify status:
-```
+
+```console
 kubectl get claim
 kubectl get composite
 kubectl get managed
 ```
 
 #### Invite App Teams to you Organization in Upbound Cloud
+
 1. Create a team `Workspace` in Upbound Cloud, named `team1`.
 1. Enable self-service APIs in each `Workspace`.
 1. Invite app team members and grant access to `Workspaces` in one or more
      `Platforms`.
 
 ### App Dev/Ops: Consume the infrastructure you need using kubectl
+
 #### Join your Organization in Upbound Cloud
+
 1. **Join** your [Upbound Cloud](https://cloud.upbound.io/register)
    `Organization`
 1. Verify access to your team `Workspaces`
 
 #### Provision a PostgreSQLInstance in your team Workspace GUI console
+
 1. Browse the available self-service APIs (XRDs) in your team `Workspace`
 1. Provision a `PostgreSQLInstance` using the custom generated GUI for your
 Platform `Configuration`
 1. View status / details in your `Workspace` GUI console
 
 #### Connect kubectl to your team Workspace
+
 1. Connect `kubectl` to a `Workspace` from the self-service GUI console in a
 `Workspace`
 
 #### Provision a PostgreSQLInstance using kubectl
-```
+
+```console
 kubectl apply -f examples/postgres-claim.yaml
 ```
 
 Verify status:
-```
+
+```console
 kubectl get claim -n team1
 kubectl get composite
 kubectl get managed
 ```
 
 ### Cleanup & Uninstall
+
 #### Cleanup Resources
+
 Delete resources created through the `Workspace` GUI:
-- From the `Workspace` GUI using the ellipsis menu in the resource view.
-- Using `kubectl delete -n team1 <claim-name>`.
+
+* From the `Workspace` GUI using the ellipsis menu in the resource view.
+* Using `kubectl delete -n team1 <claim-name>`.
 
 Delete resources created using `kubectl`:
-```
+
+```console
 kubectl delete -f examples/postgres-claim.yaml
 kubectl delete -f examples/network.yaml
 ```
 
 Verify all underlying resources have been cleanly deleted:
-```
+
+```console
 kubectl get managed
 ```
 
 #### Uninstall Provider & Platform Configuration
-```
+
+```console
 kubectl delete configurations.pkg.crossplane.io platform-ref-aws
 kubectl delete providers.pkg.crossplane.io provider-aws
+kubectl delete providers.pkg.crossplane.io provider-helm
 ```
 
-#### Uninstall Crossplane kubectl pluging
-```
+#### Uninstall Crossplane kubectl plugin
+
+```console
 rm /usr/local/bin/kubectl-crossplane*
 ```
 
 ## APIs in this Configuration
+
 * `Cluster` - provision a fully configured EKS cluster
   * [definition.yaml](cluster/definition.yaml)
   * [composition.yaml](cluster/composition.yaml) includes (transitively):
-     - `EKSCluster`
-     - `NodeGroup`
-     - `IAMRole`
-     - `IAMRolePolicyAttachment`
-     - `HelmReleases` for Prometheus and other cluster services.
+    * `EKSCluster`
+    * `NodeGroup`
+    * `IAMRole`
+    * `IAMRolePolicyAttachment`
+    * `HelmReleases` for Prometheus and other cluster services.
 * `Network` - fabric for a `Cluster` to securely connect to Data Services and
   the Internet.
   * [definition.yaml](network/definition.yaml)
   * [composition.yaml](network/composition.yaml) includes:
-    - `VPC`
-    - `Subnet`
-    - `InternetGateway`
-    - `RouteTable`
-    - `SecurityGroup` 
+    * `VPC`
+    * `Subnet`
+    * `InternetGateway`
+    * `RouteTable`
+    * `SecurityGroup`
 * `PostgreSQLInstance` - provision a PostgreSQL RDS instance that securely connects to a `Cluster`
   * [definition.yaml](database/postgres/definition.yaml)
   * [composition.yaml](database/postgres/composition.yaml) includes:
-     - `RDSInstance`
-     - `DBSubnetGroup`
+    * `RDSInstance`
+    * `DBSubnetGroup`
 
 ## Customize for your Organization
+
 Create a `Repository` called `platform-ref-aws` in your Upbound Cloud `Organization`:
 
 ![Upbound Repository](docs/media/repository.png)
 
 Set these to match your settings:
-```
+
+```console
 UPBOUND_ORG=acme
 UPBOUND_ACCOUNT_EMAIL=me@acme.io
 REPO=platform-ref-aws
@@ -216,30 +251,34 @@ REGISTRY=registry.upbound.io
 PLATFORM_CONFIG=${REGISTRY:+$REGISTRY/}${UPBOUND_ORG}/${REPO}:${VERSION_TAG}
 ```
 
-
 Clone the GitHub repo.
-```
+
+```console
 git clone https://github.com/upbound/platform-ref-aws.git
 cd platform-ref-aws
 ```
 
 Login to your container registry.
-```
+
+```console
 docker login ${REGISTRY} -u ${UPBOUND_ACCOUNT_EMAIL}
 ```
 
 Build package.
-```
+
+```console
 kubectl crossplane build configuration --name package.xpkg --ignore "examples/*"
 ```
 
 Push package to registry.
-```
+
+```console
 kubectl crossplane push configuration ${PLATFORM_CONFIG} -f package.xpkg
 ```
 
 Install package into an Upbound `Platform` instance.
-```
+
+```console
 kubectl crossplane install configuration ${PLATFORM_CONFIG}
 ```
 
@@ -251,85 +290,23 @@ To learn more see [Configuration
 Packages](https://crossplane.io/docs/v0.13/getting-started/package-infrastructure.html).
 
 ## What's Next
+
 The Crossplane community is targeting a v1.0 release with 90% coverage of all
 Cloud APIs by end of year 2020 with multiple workstreams in flight:
-1. Code gen of native Crossplane providers by adapting existing codegen pipelines:
-   - ACK Code Generation of the Crossplane `provider-aws`
-     - https://github.com/jaypipes/aws-controllers-k8s/tree/crossplane
-   - Azure Code Generation of the Crossplane `provider-azure`
-     - https://github.com/matthchr/k8s-infra/tree/crossplane-hacking
-2. Code gen of Crossplane providers that wrap the stateless Terraform providers
-   - Clouds that don't have code gen pipelines
-     - https://github.com/crossplane/crossplane/issues/262
+
+* Code gen of native Crossplane providers by adapting existing codegen pipelines:
+  * ACK Code Generation of the Crossplane `provider-aws`
+    * https://github.com/jaypipes/aws-controllers-k8s/tree/crossplane
+  * Azure Code Generation of the Crossplane `provider-azure`
+    * https://github.com/matthchr/k8s-infra/tree/crossplane-hacking
+* Code gen of Crossplane providers that wrap the stateless Terraform providers
+  * Clouds that don't have code gen pipelines
+    * https://github.com/crossplane/crossplane/issues/262
 
 ## Learn More
+
 If you're interested in building your own reference platform for your company,
 we'd love to hear from you and chat. You can setup some time with us at
 info@upbound.io.
 
-For Crossplane questions, drop by
-[slack.crossplane.io](https://slack.crossplane.io), and say hi!
-
-## Local Dev Guide
-
-These are in progress development iteration steps to run the following:
-
-* a local `kind` cluster
-* Crossplane as a helm chart from source
-* `provider-aws` in memory via `make run`
-* directly apply XRDs and Composition manifests with `kubectl`
-### kind cluster and Crossplane
-
-```console
-cluster/local/kind.sh up
-cluster/local/kind.sh helm-install
-k apply -f crossplane-cluster-admin-rolebinding.yaml
-```
-
-### `provider-aws`
-
-```console
-k apply -f package/crds/
-make run
-```
-
-### AWS reference platform
-
-Set up the AWS credentials and default AWS `ProviderConfig`:
-
-```console
-AWS_PROFILE=default && echo -e "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $AWS_PROFILE)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $AWS_PROFILE)" > creds.conf
-```
-
-```console
-kubectl create secret generic aws-creds -n crossplane-system --from-file=key=./creds.conf
-kubectl apply -f examples/aws-default-provider.yaml
-```
-
-Now create all the XRDs and Compositions:
-
-```console
-for f in $(find . -name 'definition.yaml'); do kubectl apply -f $f; done
-for f in $(find . -name 'composition.yaml'); do kubectl apply -f $f; done
-```
-
-Now create an instance of the network claim:
-
-```console
-k apply -f examples/network.yaml
-```
-
-### Clean up
-
-```console
-k delete -f examples/network.yaml
-
-for f in $(find . -name 'composition.yaml'); do k delete -f $f; done
-for f in $(find . -name 'definition.yaml'); do k delete -f $f; done
-
-kubectl delete -f examples/aws-default-provider.yaml
-kubectl -n crossplane-system delete secret aws-creds
-rm -fr creds.conf
-
-cluster/local/kind.sh clean
-```
+For Crossplane questions, drop by [slack.crossplane.io](https://slack.crossplane.io), and say hi!

--- a/cluster/composition.yaml
+++ b/cluster/composition.yaml
@@ -4,7 +4,6 @@ metadata:
   name: compositeclusters.aws.platformref.crossplane.io
 spec:
   writeConnectionSecretsToNamespace: crossplane-system
-  reclaimPolicy: Delete
   compositeTypeRef:
     apiVersion: aws.platformref.crossplane.io/v1alpha1
     kind: CompositeCluster
@@ -37,7 +36,5 @@ spec:
       patches:
         - fromFieldPath: spec.name
           toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.services.operators.prometheus.image
-          toFieldPath: spec.operators.prometheus.image
-        - fromFieldPath: spec.parameters.services.operators.prometheus.tag
-          toFieldPath: spec.operators.prometheus.tag
+        - fromFieldPath: spec.parameters.services.operators.prometheus.version
+          toFieldPath: spec.operators.prometheus.version

--- a/cluster/definition.yaml
+++ b/cluster/definition.yaml
@@ -123,12 +123,9 @@ spec:
                             type: object
                             description: Configuration for the Prometheus operator.
                             properties:
-                              image:
+                              version:
                                 type: string
-                                description: Prometheus operator image to run.
-                              tag:
-                                type: string
-                                description: Prometheus operator tag (version) to run.
+                                description: Prometheus operator version to run.
                   networkRef:
                     type: object
                     description: "A reference to the Network object that this cluster should be

--- a/cluster/eks/composition.yaml
+++ b/cluster/eks/composition.yaml
@@ -6,7 +6,6 @@ metadata:
     provider: aws
 spec:
   writeConnectionSecretsToNamespace: crossplane-system
-  reclaimPolicy: Delete
   compositeTypeRef:
     apiVersion: aws.platformref.crossplane.io/v1alpha1
     kind: EKS
@@ -58,7 +57,7 @@ spec:
                 role: controlplane
             resourcesVpcConfig:
               endpointPrivateAccess: true
-              endpointPublicAccess: false
+              endpointPublicAccess: true
             version: "1.16"
       patches:
         - fromFieldPath: metadata.annotations[crossplane.io/external-name]

--- a/cluster/services/composition.yaml
+++ b/cluster/services/composition.yaml
@@ -7,7 +7,6 @@ metadata:
     provider: helm
 spec:
   writeConnectionSecretsToNamespace: crossplane-system
-  reclaimPolicy: Delete
   compositeTypeRef:
     apiVersion: aws.platformref.crossplane.io/v1alpha1
     kind: Services
@@ -20,14 +19,11 @@ spec:
             namespace: operators
             chart:
               # from https://github.com/prometheus-community/helm-charts
-              name: prometheus-operator
+              # Note that default values are overridden by the patches below.
+              name: kube-prometheus-stack
               repository: https://prometheus-community.github.io/helm-charts
-            # Note that default values are overridden by the patches below.
-            set:
-              - name: image.repository
-                value: prom/prometheus
-              - name: image.tag
-                value: "v2.20.1"
+              version: "10.1.0"
+            values: {}
       patches:
         # All Helm releases derive their labels and annotations from the XR.
         - fromFieldPath: metadata.labels
@@ -38,7 +34,5 @@ spec:
         - fromFieldPath: spec.providerConfigRef.name
           toFieldPath: spec.providerConfigRef.name
         # Derive the Prometheus operator image and tag from the XR.
-        - fromFieldPath: spec.operators.prometheus.image
-          toFieldPath: spec.forProvider.set[0].value
-        - fromFieldPath: spec.operators.prometheus.tag
-          toFieldPath: spec.forProvider.set[1].value
+        - fromFieldPath: spec.operators.prometheus.version
+          toFieldPath: spec.forProvider.chart.version

--- a/cluster/services/definition.yaml
+++ b/cluster/services/definition.yaml
@@ -19,16 +19,14 @@ spec:
               operators:
                 type: object
                 description: Configuration for operators.
-                prometheus:
-                  type: object
-                  description: Configuration for the Prometheus operator.
-                  properties:
-                    image:
-                      type: string
-                      description: Prometheus operator image to run.
-                    tag:
-                      type: string
-                      description: Prometheus operator tag (version) to run.
+                properties:
+                  prometheus:
+                    type: object
+                    description: Configuration for the Prometheus operator.
+                    properties:
+                      version:
+                        type: string
+                        description: Prometheus operator version to run.
               providerConfigRef:
                 type: object
                 description: "A reference to the ProviderConfig of the cluster that services should

--- a/database/postgres/composition.yaml
+++ b/database/postgres/composition.yaml
@@ -19,8 +19,8 @@ spec:
             description: An excellent formation of subnetworks.
           reclaimPolicy: Delete
       patches:
-      - fromFieldPath: "spec.parameters.networkRef.name"
-        toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: "spec.parameters.networkRef.name"
+          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
     - base:
         apiVersion: database.aws.crossplane.io/v1beta1
         kind: RDSInstance
@@ -39,16 +39,16 @@ spec:
             namespace: crossplane-system
           reclaimPolicy: Delete
       patches:
-      - fromFieldPath: "metadata.uid"
-        toFieldPath: "spec.writeConnectionSecretToRef.name"
-        transforms:
-          - type: string
-            string:
-              fmt: "%s-postgresql"
-      - fromFieldPath: "spec.parameters.storageGB"
-        toFieldPath: "spec.forProvider.allocatedStorage"
-      - fromFieldPath: "spec.parameters.networkRef.name"
-        toFieldPath: spec.forProvider.vpcSecurityGroupIDSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-postgresql"
+        - fromFieldPath: "spec.parameters.storageGB"
+          toFieldPath: "spec.forProvider.allocatedStorage"
+        - fromFieldPath: "spec.parameters.networkRef.name"
+          toFieldPath: spec.forProvider.vpcSecurityGroupIDSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
       connectionDetails:
         - fromConnectionSecretKey: username
         - fromConnectionSecretKey: password

--- a/development.md
+++ b/development.md
@@ -9,10 +9,18 @@ These are in progress development iteration steps to run the following:
 
 ## kind cluster and Crossplane
 
+In the main `crossplane/crossplane` repo, run the following to bring up the cluster with the latest
+locally built Crossplane:
+
 ```console
 cluster/local/kind.sh up
 cluster/local/kind.sh helm-install
-k apply -f crossplane-cluster-admin-rolebinding.yaml
+```
+
+Back in this repo, run the following to give Crossplane admin permissions, only for development purposes:
+
+```console
+kubectl apply -f hack/crossplane-cluster-admin-rolebinding.yaml
 ```
 
 ## `provider-aws` and `provider-helm`

--- a/development.md
+++ b/development.md
@@ -19,7 +19,7 @@ k apply -f crossplane-cluster-admin-rolebinding.yaml
 
 ```console
 PROVIDER_AWS=crossplane/provider-aws:v0.12.0
-PROVIDER_HELM=crossplane/provider-helm:v0.3.0
+PROVIDER_HELM=crossplane/provider-helm:v0.3.5
 
 kubectl crossplane install provider ${PROVIDER_AWS}
 kubectl crossplane install provider ${PROVIDER_HELM}

--- a/development.md
+++ b/development.md
@@ -1,0 +1,68 @@
+# Local Dev Guide
+
+These are in progress development iteration steps to run the following:
+
+* a local `kind` cluster
+* Crossplane as a helm chart from source
+* `provider-aws` and `provider-helm` from published packages
+* directly apply XRDs and Composition manifests with `kubectl`
+
+## kind cluster and Crossplane
+
+```console
+cluster/local/kind.sh up
+cluster/local/kind.sh helm-install
+k apply -f crossplane-cluster-admin-rolebinding.yaml
+```
+
+## `provider-aws` and `provider-helm`
+
+```console
+PROVIDER_AWS=crossplane/provider-aws:v0.12.0
+PROVIDER_HELM=crossplane/provider-helm:v0.3.0
+
+kubectl crossplane install provider ${PROVIDER_AWS}
+kubectl crossplane install provider ${PROVIDER_HELM}
+kubectl get pkg
+```
+
+## AWS reference platform
+
+Set up the AWS credentials and default AWS `ProviderConfig`:
+
+```console
+AWS_PROFILE=default && echo -e "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $AWS_PROFILE)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $AWS_PROFILE)" > creds.conf
+```
+
+```console
+kubectl create secret generic aws-creds -n crossplane-system --from-file=key=./creds.conf
+kubectl apply -f examples/aws-default-provider.yaml
+```
+
+Now create all the XRDs and Compositions:
+
+```console
+for f in $(find . -name 'definition.yaml'); do kubectl apply -f $f; done
+for f in $(find . -name 'composition.yaml'); do kubectl apply -f $f; done
+```
+
+Now create an instance of the network claim:
+
+```console
+k apply -f examples/network.yaml
+```
+
+## Clean up
+
+```console
+k delete -f examples/network.yaml
+
+for f in $(find . -name 'composition.yaml'); do k delete -f $f; done
+for f in $(find . -name 'definition.yaml'); do k delete -f $f; done
+
+kubectl delete -f examples/aws-default-provider.yaml
+kubectl -n crossplane-system delete secret aws-creds
+rm -fr creds.conf
+
+cluster/local/kind.sh clean
+```

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -11,8 +11,7 @@ spec:
     services:
       operators:
         prometheus:
-          image: prom/prometheus
-          tag: v2.20.1
+          version: "10.0.2"
     networkRef:
       name: network
   writeConnectionSecretToRef:

--- a/hack/crossplane-cluster-admin-rolebinding.yaml
+++ b/hack/crossplane-cluster-admin-rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: crossplane-clusterrolebinding
+subjects:
+- kind: ServiceAccount
+  name: crossplane
+  namespace: crossplane-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: ""

--- a/network/composition.yaml
+++ b/network/composition.yaml
@@ -6,185 +6,184 @@ metadata:
     provider: aws
 spec:
   writeConnectionSecretsToNamespace: crossplane-system
-  reclaimPolicy: Delete
   compositeTypeRef:
     apiVersion: aws.platformref.crossplane.io/v1alpha1
     kind: CompositeNetwork
   resources:
-  - base:
-      apiVersion: ec2.aws.crossplane.io/v1beta1
-      kind: VPC
-      spec:
-        forProvider:
-          region: us-west-2
-          cidrBlock: 192.168.0.0/16
-          enableDnsSupport: true
-          enableDnsHostNames: true
-    patches:
-    - fromFieldPath: spec.name
-      toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
-  - base:
-      apiVersion: ec2.aws.crossplane.io/v1beta1
-      kind: InternetGateway
-      spec:
-        forProvider:
-          region: us-west-2
-          vpcIdSelector:
-            matchControllerRef: true
-    patches:
-    - fromFieldPath: spec.name
-      toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
-  - base:
-      apiVersion: ec2.aws.crossplane.io/v1beta1
-      kind: Subnet
-      metadata:
-        labels:
-          zone: us-west-2a
-          access: public
-      spec:
-        forProvider:
-          region: us-west-2
-          mapPublicIPOnLaunch: true
-          cidrBlock: 192.168.0.0/18
-          vpcIdSelector:
-            matchControllerRef: true
-          availabilityZone: us-west-2a
-          tags:
-          - key: kubernetes.io/role/elb
-            value: "1"
-    patches:
-    - fromFieldPath: spec.name
-      toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
-  - base:
-      apiVersion: ec2.aws.crossplane.io/v1beta1
-      kind: Subnet
-      metadata:
-        labels:
-          zone: us-west-2b
-          access: public
-      spec:
-        forProvider:
-          region: us-west-2
-          mapPublicIPOnLaunch: true
-          cidrBlock: 192.168.64.0/18
-          vpcIdSelector:
-            matchControllerRef: true
-          availabilityZone: us-west-2b
-          tags:
-          - key: kubernetes.io/role/elb
-            value: "1"
-    patches:
-    - fromFieldPath: spec.name
-      toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
-  - base:
-      apiVersion: ec2.aws.crossplane.io/v1beta1
-      kind: Subnet
-      metadata:
-        labels:
-          zone: us-west-2a
-          access: private
-      spec:
-        forProvider:
-          region: us-west-2
-          cidrBlock: 192.168.128.0/18
-          vpcIdSelector:
-            matchControllerRef: true
-          availabilityZone: us-west-2a
-          tags:
-          - value: shared
-            key: ""
-          - key: kubernetes.io/role/internal-elb
-            value: "1"
-    patches:
-    - fromFieldPath: spec.name
-      toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
-    - fromFieldPath: spec.clusterRef.name
-      toFieldPath: spec.forProvider.tags[0].key
-      transforms:
-      - type: string
-        string:
-          fmt: "kubernetes.io/cluster/%s"
-  - base:
-      apiVersion: ec2.aws.crossplane.io/v1beta1
-      kind: Subnet
-      metadata:
-        labels:
-          zone: us-west-2b
-          access: private
-      spec:
-        forProvider:
-          region: us-west-2
-          cidrBlock: 192.168.192.0/18
-          vpcIdSelector:
-            matchControllerRef: true
-          availabilityZone: us-west-2b
-          tags:
-          - value: shared
-            key: ""
-          - key: kubernetes.io/role/internal-elb
-            value: "1"
-    patches:
-    - fromFieldPath: spec.name
-      toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
-    - fromFieldPath: spec.clusterRef.name
-      toFieldPath: spec.forProvider.tags[0].key
-      transforms:
-      - type: string
-        string:
-          fmt: "kubernetes.io/cluster/%s"
-  - base:
-      apiVersion: ec2.aws.crossplane.io/v1alpha4
-      kind: RouteTable
-      spec:
-        forProvider:
-          region: us-west-2
-          vpcIdSelector:
-            matchControllerRef: true
-          routes:
-            - destinationCidrBlock: 0.0.0.0/0
-              gatewayIdSelector:
-                matchControllerRef: true
-          associations:
-            - subnetIdSelector:
-                matchControllerRef: true
-                matchLabels:
-                  zone: us-west-2a
-                  access: public
-            - subnetIdSelector:
-                matchControllerRef: true
-                matchLabels:
-                  zone: us-west-2b
-                  access: public
-            - subnetIdSelector:
-                matchControllerRef: true
-                matchLabels:
-                  zone: us-west-2a
-                  access: private
-            - subnetIdSelector:
-                matchControllerRef: true
-                matchLabels:
-                  zone: us-west-2b
-                  access: private
-    patches:
-    - fromFieldPath: spec.name
-      toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
-  - base:
-      apiVersion: ec2.aws.crossplane.io/v1beta1
-      kind: SecurityGroup
-      spec:
-        forProvider:
-          region: us-west-2
-          vpcIdSelector:
-            matchControllerRef: true
-          groupName: platform-ref-aws-cluster
-          description: Allow access to PostgreSQL
-          ingress:
-            - fromPort: 5432
-              toPort: 5432
-              ipProtocol: tcp
-              ipRanges:
-                - cidrIp: 0.0.0.0/0
-                  description: Everywhere
-    patches:
-    - fromFieldPath: spec.name
-      toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+    - base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: VPC
+        spec:
+          forProvider:
+            region: us-west-2
+            cidrBlock: 192.168.0.0/16
+            enableDnsSupport: true
+            enableDnsHostNames: true
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+    - base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: InternetGateway
+        spec:
+          forProvider:
+            region: us-west-2
+            vpcIdSelector:
+              matchControllerRef: true
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+    - base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            zone: us-west-2a
+            access: public
+        spec:
+          forProvider:
+            region: us-west-2
+            mapPublicIPOnLaunch: true
+            cidrBlock: 192.168.0.0/18
+            vpcIdSelector:
+              matchControllerRef: true
+            availabilityZone: us-west-2a
+            tags:
+              - key: kubernetes.io/role/elb
+                value: "1"
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+    - base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            zone: us-west-2b
+            access: public
+        spec:
+          forProvider:
+            region: us-west-2
+            mapPublicIPOnLaunch: true
+            cidrBlock: 192.168.64.0/18
+            vpcIdSelector:
+              matchControllerRef: true
+            availabilityZone: us-west-2b
+            tags:
+              - key: kubernetes.io/role/elb
+                value: "1"
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+    - base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            zone: us-west-2a
+            access: private
+        spec:
+          forProvider:
+            region: us-west-2
+            cidrBlock: 192.168.128.0/18
+            vpcIdSelector:
+              matchControllerRef: true
+            availabilityZone: us-west-2a
+            tags:
+              - value: shared
+                key: ""
+              - key: kubernetes.io/role/internal-elb
+                value: "1"
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: spec.clusterRef.name
+          toFieldPath: spec.forProvider.tags[0].key
+          transforms:
+            - type: string
+              string:
+                fmt: "kubernetes.io/cluster/%s"
+    - base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            zone: us-west-2b
+            access: private
+        spec:
+          forProvider:
+            region: us-west-2
+            cidrBlock: 192.168.192.0/18
+            vpcIdSelector:
+              matchControllerRef: true
+            availabilityZone: us-west-2b
+            tags:
+              - value: shared
+                key: ""
+              - key: kubernetes.io/role/internal-elb
+                value: "1"
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: spec.clusterRef.name
+          toFieldPath: spec.forProvider.tags[0].key
+          transforms:
+            - type: string
+              string:
+                fmt: "kubernetes.io/cluster/%s"
+    - base:
+        apiVersion: ec2.aws.crossplane.io/v1alpha4
+        kind: RouteTable
+        spec:
+          forProvider:
+            region: us-west-2
+            vpcIdSelector:
+              matchControllerRef: true
+            routes:
+              - destinationCidrBlock: 0.0.0.0/0
+                gatewayIdSelector:
+                  matchControllerRef: true
+            associations:
+              - subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    zone: us-west-2a
+                    access: public
+              - subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    zone: us-west-2b
+                    access: public
+              - subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    zone: us-west-2a
+                    access: private
+              - subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    zone: us-west-2b
+                    access: private
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+    - base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: SecurityGroup
+        spec:
+          forProvider:
+            region: us-west-2
+            vpcIdSelector:
+              matchControllerRef: true
+            groupName: platform-ref-aws-cluster
+            description: Allow access to PostgreSQL
+            ingress:
+              - fromPort: 5432
+                toPort: 5432
+                ipProtocol: tcp
+                ipRanges:
+                  - cidrIp: 0.0.0.0/0
+                    description: Everywhere
+      patches:
+        - fromFieldPath: spec.name
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]


### PR DESCRIPTION
* include provider-helm install and clean-up steps
* make readme lint clean
* move local dev steps to its own guide outside of main readme
* remove obsolete reclaimPolicy from Compositions
* bump provider-helm to v0.3.3
* enable endpointPublicAccess so provider-helm can reach EKS api-server
* update services schema to set prometheus chart version