### PR TITLE
readme: add ignore hack/* to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ docker login ${REGISTRY} -u ${UPBOUND_ACCOUNT_EMAIL}
 Build package.
 
 ```console
-kubectl crossplane build configuration --name package.xpkg --ignore "examples/*"
+kubectl crossplane build configuration --name package.xpkg --ignore "examples/*,hack/*"
 ```
 
 Push package to registry.


### PR DESCRIPTION
This PR adds an additional ignore clause to the build instructions, to also ignore the new `hack` directory.

Without this ignore, the build fails with:
```
> kubectl crossplane build configuration --name package.xpkg --ignore "examples/*"
kubectl crossplane: error: failed to build package: failed to parse package: no kind "ClusterRoleBinding" is registered for version "rbac.authorization.k8s.io/v1beta1" in scheme "pkg/runtime/scheme.go:101"
```