### PR TITLE
readme: bump instructions to v0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ kubectl apply -f examples/aws-default-provider.yaml
 #### Install the Platform Configuration
 
 ```console
-PLATFORM_CONFIG=registry.upbound.io/upbound/platform-ref-aws:v0.0.1
+PLATFORM_CONFIG=registry.upbound.io/upbound/platform-ref-aws:v0.0.2
 
 kubectl crossplane install configuration ${PLATFORM_CONFIG}
 kubectl get pkg
@@ -246,7 +246,7 @@ Set these to match your settings:
 UPBOUND_ORG=acme
 UPBOUND_ACCOUNT_EMAIL=me@acme.io
 REPO=platform-ref-aws
-VERSION_TAG=v0.0.1
+VERSION_TAG=v0.0.2
 REGISTRY=registry.upbound.io
 PLATFORM_CONFIG=${REGISTRY:+$REGISTRY/}${UPBOUND_ORG}/${REPO}:${VERSION_TAG}
 ```


### PR DESCRIPTION
This PR bumps the readme instructions for installing the AWS reference platform to use the newly published v0.0.2 package available as `registry.upbound.io/upbound/platform-ref-aws:v0.0.2`.