### PR TITLE
make compatible with crossplane v0.14-rc breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cp kubectl-crossplane /usr/local/bin
 #### Install Providers into your Platform
 
 ```console
-PROVIDER_AWS=crossplane/provider-aws:v0.12.0
+PROVIDER_AWS=crossplane/provider-aws:v0.13.0
 PROVIDER_HELM=crossplane/provider-helm:v0.3.5
 
 kubectl crossplane install provider ${PROVIDER_AWS}

--- a/cluster/definition.yaml
+++ b/cluster/definition.yaml
@@ -50,22 +50,13 @@ metadata:
       - title: Cluster Services
         description: Configure cluster services and operators
         items:
-        - name: promImage
+        - name: promVersion
           controlType: singleInput
           type: string
-          path: ".spec.parameters.services.prometheus.image"
-          title: Prometheus Image
-          description: operator image to run
-          default: prom/promethueus
-          validation:
-          - required: false
-        - name: promImageTag
-          controlType: singleInput
-          type: string
-          path: ".spec.parameters.services.prometheus.tag"
-          title: Prometheus Image Tag
-          description: operator image tag to use
-          default: v2.21.0
+          path: ".spec.parameters.services.operators.prometheus.version"
+          title: Prometheus Chart Version
+          description: The version of kube-prometheus-stack chart to install
+          default: 10.1.0
           validation:
           - required: false
 spec:
@@ -74,13 +65,15 @@ spec:
     plural: clusters
   connectionSecretKeys:
   - kubeconfig
-  crdSpecTemplate:
-    group: aws.platformref.crossplane.io
-    version: v1alpha1
-    names:
-      kind: CompositeCluster
-      plural: compositeclusters
-    validation:
+  group: aws.platformref.crossplane.io
+  names:
+    kind: CompositeCluster
+    plural: compositeclusters
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
       openAPIV3Schema:
         type: object
         properties:

--- a/cluster/eks/definition.yaml
+++ b/cluster/eks/definition.yaml
@@ -5,13 +5,15 @@ metadata:
 spec:
   connectionSecretKeys:
   - kubeconfig
-  crdSpecTemplate:
-    group: aws.platformref.crossplane.io
-    version: v1alpha1
-    names:
-      kind: EKS
-      plural: eks
-    validation:
+  group: aws.platformref.crossplane.io
+  names:
+    kind: EKS
+    plural: eks
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
       openAPIV3Schema:
         type: object
         properties:

--- a/cluster/services/definition.yaml
+++ b/cluster/services/definition.yaml
@@ -3,13 +3,15 @@ kind: CompositeResourceDefinition
 metadata:
   name: services.aws.platformref.crossplane.io
 spec:
-  crdSpecTemplate:
-    group: aws.platformref.crossplane.io
-    version: v1alpha1
-    names:
-      kind: Services
-      plural: services
-    validation:
+  group: aws.platformref.crossplane.io
+  names:
+    kind: Services
+    plural: services
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
       openAPIV3Schema:
         type: object
         properties:

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -12,7 +12,8 @@ metadata:
       This configuration serves as a reference platform for cloud native services
       and applications running in AWS.
 spec:
-  crossplane: v0.13.0
+  crossplane:
+    version: ">=v0.14.0-0"
   dependsOn:
-  - provider: crossplane/provider-aws
-    version: v0.12.0
+    - provider: crossplane/provider-aws
+      version: v0.13.0

--- a/database/postgres/definition.yaml
+++ b/database/postgres/definition.yaml
@@ -48,13 +48,15 @@ spec:
     - password
     - endpoint
     - port
-  crdSpecTemplate:
-    group: aws.platformref.crossplane.io
-    version: v1alpha1
-    names:
-      kind: CompositePostgreSQLInstance
-      plural: compositepostgresqlinstances
-    validation:
+  group: aws.platformref.crossplane.io
+  names:
+    kind: CompositePostgreSQLInstance
+    plural: compositepostgresqlinstances
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
       openAPIV3Schema:
         type: object
         properties:

--- a/network/definition.yaml
+++ b/network/definition.yaml
@@ -23,31 +23,33 @@ spec:
   claimNames:
     kind: Network
     plural: networks
-  crdSpecTemplate:
-    group: aws.platformref.crossplane.io
-    version: v1alpha1
-    names:
-      kind: CompositeNetwork
-      plural: compositenetworks
-    validation:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              name:
-                type: string
-                description: Name of this Network that other objects will use to refer to it.
-              clusterRef:
-                type: object
-                description: "A reference to the Cluster object that this network will be used for."
-                properties:
-                  name:
-                    type: string
-                    description: Name of the Cluster object this ref points to.
-                required:
+  group: aws.platformref.crossplane.io
+  names:
+    kind: CompositeNetwork
+    plural: compositenetworks
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Name of this Network that other objects will use to refer to it.
+                clusterRef:
+                  type: object
+                  description: "A reference to the Cluster object that this network will be used for."
+                  properties:
+                    name:
+                      type: string
+                      description: Name of the Cluster object this ref points to.
+                  required:
+                    - name
+              required:
                 - name
-            required:
-            - name
-            - clusterRef
+                - clusterRef


### PR DESCRIPTION
* update XRDs to support multiple versions
* update crossplane.yaml version constraints
* also fix prometheus UI config annotations for chart version

Followed @negz instructions for upgrading to v0.14 on https://crossplane.io/docs/master/guides/upgrading-to-v0.14.html.

Tested by building locally and installing into local kind cluster with Crossplane `v0.14.0-rc.102.g6e1b4ce2`.

Package is installed and healthy, and all XRDs are established and offered:
```
> k get xrd
NAME                                                         ESTABLISHED   OFFERED   AGE
compositeclusters.aws.platformref.crossplane.io              True          True      36s
compositenetworks.aws.platformref.crossplane.io              True          True      35s
compositepostgresqlinstances.aws.platformref.crossplane.io   True          True      35s
eks.aws.platformref.crossplane.io                            True                    36s
services.aws.platformref.crossplane.io                       True                    35s
```

I also created a Network object that resulted in successful AWS managed resources:
```
> k get managed
NAME                                               READY   SYNCED   ID                         VPC                     CIDR               AGE
subnet.ec2.aws.crossplane.io/network-skjbd-k57xw   True    True     subnet-028d3f1724971e317   vpc-01e78b028202ca1f7   192.168.192.0/18   90s
subnet.ec2.aws.crossplane.io/network-skjbd-t5kbx   True    True     subnet-0b54145157ef51098   vpc-01e78b028202ca1f7   192.168.0.0/18     90s
subnet.ec2.aws.crossplane.io/network-skjbd-v297n   True    True     subnet-0d16ed5b00935761d   vpc-01e78b028202ca1f7   192.168.128.0/18   90s
subnet.ec2.aws.crossplane.io/network-skjbd-w82bg   True    True     subnet-0ed86ea055389530b   vpc-01e78b028202ca1f7   192.168.64.0/18    90s

NAME                                            READY   SYNCED   ID                      CIDR             AGE
vpc.ec2.aws.crossplane.io/network-skjbd-9v6nz   True    True     vpc-01e78b028202ca1f7   192.168.0.0/16   90s

NAME                                                        READY   SYNCED   ID                      VPC                     AGE
internetgateway.ec2.aws.crossplane.io/network-skjbd-z4wcd   True    True     igw-0577712b369090bd8   vpc-01e78b028202ca1f7   90s

NAME                                                      READY   SYNCED   ID                     VPC                     AGE
securitygroup.ec2.aws.crossplane.io/network-skjbd-qnpf2   True    True     sg-08c5a952e042be64d   vpc-01e78b028202ca1f7   89s

NAME                                                   READY   SYNCED   ID                      VPC                     AGE
routetable.ec2.aws.crossplane.io/network-skjbd-jh2mn   True    True     rtb-0c8be0cb09a296f97   vpc-01e78b028202ca1f7   89s
```