### PR TITLE
Fixes for all types to be properly configured via UI

### DIFF
--- a/cluster/composition.yaml
+++ b/cluster/composition.yaml
@@ -11,6 +11,8 @@ spec:
     - base:
         apiVersion: aws.platformref.crossplane.io/v1alpha1
         kind: EKS
+      connectionDetails:
+        - fromConnectionSecretKey: kubeconfig
       patches:
         - fromFieldPath: spec.id
           toFieldPath: spec.id

--- a/cluster/composition.yaml
+++ b/cluster/composition.yaml
@@ -12,9 +12,9 @@ spec:
         apiVersion: aws.platformref.crossplane.io/v1alpha1
         kind: EKS
       patches:
-        - fromFieldPath: spec.name
-          toFieldPath: spec.name
-        - fromFieldPath: spec.name
+        - fromFieldPath: spec.id
+          toFieldPath: spec.id
+        - fromFieldPath: spec.id
           toFieldPath: metadata.annotations[crossplane.io/external-name]
         - fromFieldPath: metadata.uid
           toFieldPath: spec.writeConnectionSecretToRef.name
@@ -28,13 +28,13 @@ spec:
           toFieldPath: spec.parameters.nodes.count
         - fromFieldPath: spec.parameters.nodes.size
           toFieldPath: spec.parameters.nodes.size
-        - fromFieldPath: spec.parameters.networkRef.name
-          toFieldPath: spec.parameters.networkRef.name
+        - fromFieldPath: spec.parameters.networkRef.id
+          toFieldPath: spec.parameters.networkRef.id
     - base:
         apiVersion: aws.platformref.crossplane.io/v1alpha1
         kind: Services
       patches:
-        - fromFieldPath: spec.name
+        - fromFieldPath: spec.id
           toFieldPath: spec.providerConfigRef.name
         - fromFieldPath: spec.parameters.services.operators.prometheus.version
           toFieldPath: spec.operators.prometheus.version

--- a/cluster/definition.yaml
+++ b/cluster/definition.yaml
@@ -15,7 +15,7 @@ metadata:
           path: ".spec.id"
           title: Cluster ID
           description: Cluster ID that other objects will use to refer to this cluster
-          default: cluster
+          default: platform-ref-aws-cluster
           validation:
           - required: true
             customError: Cluster ID is required.
@@ -56,7 +56,7 @@ metadata:
           path: ".spec.parameters.networkRef.id"
           title: Network Ref
           description: Network fabric to connect the database to
-          default: network
+          default: platform-ref-aws-network
           validation:
           - required: true
             customError: Network ref is required.

--- a/cluster/definition.yaml
+++ b/cluster/definition.yaml
@@ -6,6 +6,19 @@ metadata:
     upbound.io/ui-schema: |-
       ---
       configSections:
+      - title: Cluster Info
+        description: Information about this cluster
+        items:
+        - name: id
+          controlType: singleInput
+          type: string
+          path: ".spec.id"
+          title: Cluster ID
+          description: Cluster ID that other objects will use to refer to this cluster
+          default: cluster
+          validation:
+          - required: true
+            customError: Cluster ID is required.
       - title: Cluster Nodes
         description: Enter information to size your cluster
         items:
@@ -40,7 +53,7 @@ metadata:
         - name: networkRef
           controlType: singleInput
           type: string
-          path: ".spec.parameters.networkRef.name"
+          path: ".spec.parameters.networkRef.id"
           title: Network Ref
           description: Network fabric to connect the database to
           default: network
@@ -80,9 +93,9 @@ spec:
           spec:
             type: object
             properties:
-              name:
+              id:
                 type: string
-                description: Name of this Cluster that other objects will use to refer to it.
+                description: ID of this Cluster that other objects will use to refer to it.
               parameters:
                 type: object
                 description: Cluster configuration parameters.
@@ -124,11 +137,11 @@ spec:
                     description: "A reference to the Network object that this cluster should be
                     connected to."
                     properties:
-                      name:
+                      id:
                         type: string
-                        description: Name of the Network object this ref points to.
+                        description: ID of the Network object this ref points to.
                     required:
-                    - name
+                    - id
                 required:
                 - nodes
                 - networkRef

--- a/cluster/eks/composition.yaml
+++ b/cluster/eks/composition.yaml
@@ -70,8 +70,8 @@ spec:
                 fmt: "%s-ekscluster"
         - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: "spec.parameters.networkRef.name"
-          toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: "spec.parameters.networkRef.id"
+          toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
       connectionDetails:
         - fromConnectionSecretKey: kubeconfig
     - base:
@@ -163,8 +163,8 @@ spec:
                 small: t3.small
                 medium: t3.medium
                 large: t3.large
-        - fromFieldPath: "spec.parameters.networkRef.name"
-          toFieldPath: spec.forProvider.subnetSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: "spec.parameters.networkRef.id"
+          toFieldPath: spec.forProvider.subnetSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
     - base:
         apiVersion: helm.crossplane.io/v1alpha1
         kind: ProviderConfig
@@ -175,7 +175,7 @@ spec:
               namespace: crossplane-system
               key: kubeconfig
       patches:
-        - fromFieldPath: spec.name
+        - fromFieldPath: spec.id
           toFieldPath: metadata.name
         # This ProviderConfig uses the above EKS cluster's connection secret as
         # its credentials secret.

--- a/cluster/eks/definition.yaml
+++ b/cluster/eks/definition.yaml
@@ -20,9 +20,9 @@ spec:
           spec:
             type: object
             properties:
-              name:
+              id:
                 type: string
-                description: Name of this Cluster that other objects will use to refer to it.
+                description: ID of this Cluster that other objects will use to refer to it.
               parameters:
                 type: object
                 description: EKS configuration parameters.
@@ -49,11 +49,11 @@ spec:
                     description: "A reference to the Network object that this postgres should be
                     connected to."
                     properties:
-                      name:
+                      id:
                         type: string
-                        description: Name of the Network object this ref points to.
+                        description: ID of the Network object this ref points to.
                     required:
-                    - name
+                    - id
                 required:
                 - nodes
                 - networkRef

--- a/database/postgres/composition.yaml
+++ b/database/postgres/composition.yaml
@@ -19,8 +19,8 @@ spec:
             description: An excellent formation of subnetworks.
           reclaimPolicy: Delete
       patches:
-        - fromFieldPath: "spec.parameters.networkRef.name"
-          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: "spec.parameters.networkRef.id"
+          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
     - base:
         apiVersion: database.aws.crossplane.io/v1beta1
         kind: RDSInstance
@@ -47,8 +47,8 @@ spec:
                 fmt: "%s-postgresql"
         - fromFieldPath: "spec.parameters.storageGB"
           toFieldPath: "spec.forProvider.allocatedStorage"
-        - fromFieldPath: "spec.parameters.networkRef.name"
-          toFieldPath: spec.forProvider.vpcSecurityGroupIDSelector.matchLabels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: "spec.parameters.networkRef.id"
+          toFieldPath: spec.forProvider.vpcSecurityGroupIDSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
       connectionDetails:
         - fromConnectionSecretKey: username
         - fromConnectionSecretKey: password

--- a/database/postgres/definition.yaml
+++ b/database/postgres/definition.yaml
@@ -23,7 +23,7 @@ metadata:
         - name: networkRef
           controlType: singleInput
           type: string
-          path: ".spec.parameters.networkRef.name"
+          path: ".spec.parameters.networkRef.id"
           title: Network Ref
           description: Network fabric to connect the database to
           default: network
@@ -73,11 +73,11 @@ spec:
                     description: "A reference to the Network object that this postgres should be
                     connected to."
                     properties:
-                      name:
+                      id:
                         type: string
-                        description: Name of the Network object this ref points to.
+                        description: ID of the Network object this ref points to.
                     required:
-                    - name
+                    - id
                 required:
                   - storageGB
                   - networkRef

--- a/database/postgres/definition.yaml
+++ b/database/postgres/definition.yaml
@@ -26,7 +26,7 @@ metadata:
           path: ".spec.parameters.networkRef.id"
           title: Network Ref
           description: Network fabric to connect the database to
-          default: network
+          default: platform-ref-aws-network
           validation:
           - required: true
             customError: Network ref is required and should match the network ref of the app cluster.

--- a/development.md
+++ b/development.md
@@ -26,7 +26,7 @@ kubectl apply -f hack/crossplane-cluster-admin-rolebinding.yaml
 ## `provider-aws` and `provider-helm`
 
 ```console
-PROVIDER_AWS=crossplane/provider-aws:v0.12.0
+PROVIDER_AWS=crossplane/provider-aws:v0.13.0
 PROVIDER_HELM=crossplane/provider-helm:v0.3.5
 
 kubectl crossplane install provider ${PROVIDER_AWS}

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: platform-ref-aws-cluster
 spec:
-  name: platform-ref-aws-cluster
+  id: platform-ref-aws-cluster
   parameters:
     nodes:
       count: 3
@@ -13,6 +13,6 @@ spec:
         prometheus:
           version: "10.0.2"
     networkRef:
-      name: network
+      id: platform-ref-aws-network
   writeConnectionSecretToRef:
     name: platform-ref-aws-cluster

--- a/examples/network.yaml
+++ b/examples/network.yaml
@@ -3,6 +3,6 @@ kind: Network
 metadata:
   name: network
 spec:
-  name: network
+  id: platform-ref-aws-network
   clusterRef:
-    name: platform-ref-aws-cluster
+    id: platform-ref-aws-cluster

--- a/examples/postgres-claim.yaml
+++ b/examples/postgres-claim.yaml
@@ -2,11 +2,10 @@ apiVersion: aws.platformref.crossplane.io/v1alpha1
 kind: PostgreSQLInstance
 metadata:
   name: my-db
-  namespace: team1
 spec:
   parameters:
     storageGB: 20
     networkRef:
-      name: network
+      id: platform-ref-aws-network
   writeConnectionSecretToRef:
     name: my-db-conn

--- a/network/composition.yaml
+++ b/network/composition.yaml
@@ -20,8 +20,8 @@ spec:
             enableDnsSupport: true
             enableDnsHostNames: true
       patches:
-        - fromFieldPath: spec.name
-          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: spec.id
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-id]
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: InternetGateway
@@ -31,8 +31,8 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
       patches:
-        - fromFieldPath: spec.name
-          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: spec.id
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-id]
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: Subnet
@@ -52,8 +52,8 @@ spec:
               - key: kubernetes.io/role/elb
                 value: "1"
       patches:
-        - fromFieldPath: spec.name
-          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: spec.id
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-id]
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: Subnet
@@ -73,8 +73,8 @@ spec:
               - key: kubernetes.io/role/elb
                 value: "1"
       patches:
-        - fromFieldPath: spec.name
-          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: spec.id
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-id]
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: Subnet
@@ -95,9 +95,9 @@ spec:
               - key: kubernetes.io/role/internal-elb
                 value: "1"
       patches:
-        - fromFieldPath: spec.name
-          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
-        - fromFieldPath: spec.clusterRef.name
+        - fromFieldPath: spec.id
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-id]
+        - fromFieldPath: spec.clusterRef.id
           toFieldPath: spec.forProvider.tags[0].key
           transforms:
             - type: string
@@ -123,9 +123,9 @@ spec:
               - key: kubernetes.io/role/internal-elb
                 value: "1"
       patches:
-        - fromFieldPath: spec.name
-          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
-        - fromFieldPath: spec.clusterRef.name
+        - fromFieldPath: spec.id
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-id]
+        - fromFieldPath: spec.clusterRef.id
           toFieldPath: spec.forProvider.tags[0].key
           transforms:
             - type: string
@@ -165,8 +165,8 @@ spec:
                     zone: us-west-2b
                     access: private
       patches:
-        - fromFieldPath: spec.name
-          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: spec.id
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-id]
     - base:
         apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: SecurityGroup
@@ -185,5 +185,5 @@ spec:
                   - cidrIp: 0.0.0.0/0
                     description: Everywhere
       patches:
-        - fromFieldPath: spec.name
-          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-name]
+        - fromFieldPath: spec.id
+          toFieldPath: metadata.labels[networks.aws.platformref.crossplane.io/network-id]

--- a/network/definition.yaml
+++ b/network/definition.yaml
@@ -6,15 +6,28 @@ metadata:
     upbound.io/ui-schema: |-
       ---
       configSections:
+      - title: Network Info
+        description: Information about this network fabric
+        items:
+        - name: id
+          controlType: singleInput
+          type: string
+          path: ".spec.id"
+          title: Network ID
+          description: Network ID that other objects will use to refer (and connect) to this network fabric
+          default: network
+          validation:
+          - required: true
+            customError: Network ID is required.
       - title: Cluster Info
         description: The cluster used with this network fabric
         items:
         - name: clusterRef
           controlType: singleInput
           type: string
-          path: ".spec.parameters.clusterRef.name"
+          path: ".spec.clusterRef.id"
           title: Network Ref
-          description: Name of the Cluster object this ref points to
+          description: ID of the Cluster object that will use this network fabric
           default: cluster
           validation:
           - required: true
@@ -38,18 +51,18 @@ spec:
             spec:
               type: object
               properties:
-                name:
+                id:
                   type: string
-                  description: Name of this Network that other objects will use to refer to it.
+                  description: ID of this Network that other objects will use to refer to it.
                 clusterRef:
                   type: object
                   description: "A reference to the Cluster object that this network will be used for."
                   properties:
-                    name:
+                    id:
                       type: string
-                      description: Name of the Cluster object this ref points to.
+                      description: ID of the Cluster object this ref points to.
                   required:
-                    - name
+                    - id
               required:
-                - name
+                - id
                 - clusterRef

--- a/network/definition.yaml
+++ b/network/definition.yaml
@@ -15,7 +15,7 @@ metadata:
           path: ".spec.id"
           title: Network ID
           description: Network ID that other objects will use to refer (and connect) to this network fabric
-          default: network
+          default: platform-ref-aws-network
           validation:
           - required: true
             customError: Network ID is required.
@@ -26,9 +26,9 @@ metadata:
           controlType: singleInput
           type: string
           path: ".spec.clusterRef.id"
-          title: Network Ref
+          title: Cluster Ref
           description: ID of the Cluster object that will use this network fabric
-          default: cluster
+          default: platform-ref-aws-cluster
           validation:
           - required: true
             customError: Cluster ref is required.


### PR DESCRIPTION
* standardize on ID instead of name for references, making it more
  explicit in the UI that this is separate from the K8s object name.
* Add UI elements for ID fields
* ensure EKS connection secret is propagated to parent composition