### PR TITLE
remove markdown from crossplane yaml description

### DIFF
--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -12,7 +12,7 @@ metadata:
       The AWS reference platform for Kubernetes and Data Services.
 
     description: |
-      This reference platform `Configuration` for Kubernetes and Data Services
+      This reference platform Configuration for Kubernetes and Data Services
       is a starting point to build, run, and operate your own internal cloud
       platform and offer a self-service console and API to your internal teams.
 


### PR DESCRIPTION
Configuration was marked as `Configuration` which isn't supported in the crossplane.yaml `description` field.

Signed-off-by: Phil Prasek <prasek@gmail.com>