### PR TITLE
e2e fixes for EKS workload connectivity to postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cp kubectl-crossplane /usr/local/bin
 #### Install Providers into your Platform
 
 ```console
-PROVIDER_AWS=crossplane/provider-aws:v0.14.0-rc.0
+PROVIDER_AWS=crossplane/provider-aws:v0.14.0
 PROVIDER_HELM=crossplane/provider-helm:v0.3.6
 
 kubectl crossplane install provider ${PROVIDER_AWS}
@@ -112,7 +112,7 @@ kubectl apply -f examples/aws-default-provider.yaml
 #### Install the Platform Configuration
 
 ```console
-PLATFORM_CONFIG=registry.upbound.io/upbound/platform-ref-aws:v0.0.7
+PLATFORM_CONFIG=registry.upbound.io/upbound/platform-ref-aws:v0.0.8
 
 kubectl crossplane install configuration ${PLATFORM_CONFIG}
 kubectl get pkg
@@ -246,7 +246,7 @@ Set these to match your settings:
 UPBOUND_ORG=acme
 UPBOUND_ACCOUNT_EMAIL=me@acme.io
 REPO=platform-ref-aws
-VERSION_TAG=v0.0.7
+VERSION_TAG=v0.0.8
 REGISTRY=registry.upbound.io
 PLATFORM_CONFIG=${REGISTRY:+$REGISTRY/}${UPBOUND_ORG}/${REPO}:${VERSION_TAG}
 ```

--- a/cluster/definition.yaml
+++ b/cluster/definition.yaml
@@ -19,6 +19,15 @@ metadata:
           validation:
           - required: true
             customError: Cluster ID is required.
+        - name: writeSecretRef
+          controlType: singleInput
+          type: string
+          path: ".spec.writeConnectionSecretToRef.name"
+          title: Connection Secret Ref
+          description: name of the secret to write to this namespace
+          default: cluster-conn
+          validation:
+          - required: true
       - title: Cluster Nodes
         description: Enter information to size your cluster
         items:

--- a/cluster/eks/composition.yaml
+++ b/cluster/eks/composition.yaml
@@ -71,6 +71,8 @@ spec:
         - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.writeConnectionSecretToRef.namespace
         - fromFieldPath: "spec.parameters.networkRef.id"
+          toFieldPath: spec.forProvider.resourcesVpcConfig.securityGroupIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
+        - fromFieldPath: "spec.parameters.networkRef.id"
           toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
       connectionDetails:
         - fromConnectionSecretKey: kubeconfig

--- a/development.md
+++ b/development.md
@@ -26,7 +26,7 @@ kubectl apply -f hack/crossplane-cluster-admin-rolebinding.yaml
 ## `provider-aws` and `provider-helm`
 
 ```console
-PROVIDER_AWS=crossplane/provider-aws:v0.14.0-rc.0
+PROVIDER_AWS=crossplane/provider-aws:v0.14.0
 PROVIDER_HELM=crossplane/provider-helm:v0.3.6
 
 kubectl crossplane install provider ${PROVIDER_AWS}


### PR DESCRIPTION
* Add connection scret to cluster UI config spec so that EKS connection secret
  is propagated to claim namespace
* Add security group selector to EKS managed resource, ensuring it uses same
  security group as RDS postgres instance
* Bump provider-aws to official v0.14.0 release
* Bump platform-ref-aws to v0.0.8 ahead of release

Signed-off-by: Jared Watts <jbw976@gmail.com>