### PR TITLE
Bump XRDs and Compositions to v1beta1

### DIFF
--- a/cluster/composition.yaml
+++ b/cluster/composition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1beta1
 kind: Composition
 metadata:
   name: compositeclusters.aws.platformref.crossplane.io

--- a/cluster/definition.yaml
+++ b/cluster/definition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1beta1
 kind: CompositeResourceDefinition
 metadata:
   name: compositeclusters.aws.platformref.crossplane.io

--- a/cluster/eks/composition.yaml
+++ b/cluster/eks/composition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1beta1
 kind: Composition
 metadata:
   name: eks.aws.platformref.crossplane.io

--- a/cluster/eks/definition.yaml
+++ b/cluster/eks/definition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1beta1
 kind: CompositeResourceDefinition
 metadata:
   name: eks.aws.platformref.crossplane.io

--- a/cluster/services/composition.yaml
+++ b/cluster/services/composition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1beta1
 kind: Composition
 metadata:
   name: services.aws.platformref.crossplane.io

--- a/cluster/services/definition.yaml
+++ b/cluster/services/definition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1beta1
 kind: CompositeResourceDefinition
 metadata:
   name: services.aws.platformref.crossplane.io

--- a/database/postgres/composition.yaml
+++ b/database/postgres/composition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1beta1
 kind: Composition
 metadata:
   name: compositepostgresqlinstances.aws.platformref.crossplane.io

--- a/database/postgres/definition.yaml
+++ b/database/postgres/definition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1beta1
 kind: CompositeResourceDefinition
 metadata:
   name: compositepostgresqlinstances.aws.platformref.crossplane.io

--- a/network/composition.yaml
+++ b/network/composition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1beta1
 kind: Composition
 metadata:
   name: compositenetworks.aws.platformref.crossplane.io

--- a/network/definition.yaml
+++ b/network/definition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1beta1
 kind: CompositeResourceDefinition
 metadata:
   name: compositenetworks.aws.platformref.crossplane.io


### PR DESCRIPTION
Crossplane v1.0 drops support for v1alpha1 apiextensions.crossplane.io
types. This bumps them to v1alpha1 to remain compatible.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>