### PR TITLE
fix: reclaimPolicy -> deletionPolicy in postgres composition.yaml

### DIFF
--- a/database/postgres/composition.yaml
+++ b/database/postgres/composition.yaml
@@ -17,7 +17,7 @@ spec:
           forProvider:
             region: us-west-2
             description: An excellent formation of subnetworks.
-          reclaimPolicy: Delete
+          deletionPolicy: Delete
       patches:
         - fromFieldPath: "spec.parameters.networkRef.id"
           toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
@@ -37,7 +37,7 @@ spec:
             publiclyAccessible: false
           writeConnectionSecretToRef:
             namespace: crossplane-system
-          reclaimPolicy: Delete
+          deletionPolicy: Delete
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"


### PR DESCRIPTION
Found this when using the cdk8s generated types in [crossplane-cdk#7](https://github.com/crossplane-contrib/crossplane-cdk/pull/7/commits/0bae5ca545db731e19d23d8c8ff8d223633c9b06#diff-201d3c4e347009c6ca30ab98c11c9830177d239bd57d320173c2fe3b52612c6c)

Signed-off-by: Phil Prasek <prasek@gmail.com>