### PR TITLE
Patch the connection secret namespace for postgres RDS also

### DIFF
--- a/database/postgres/composition.yaml
+++ b/database/postgres/composition.yaml
@@ -43,6 +43,8 @@ spec:
             - type: string
               string:
                 fmt: "%s-postgresql"
+        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
         - fromFieldPath: "spec.parameters.storageGB"
           toFieldPath: "spec.forProvider.allocatedStorage"
         - fromFieldPath: "spec.parameters.networkRef.id"


### PR DESCRIPTION
This PR ensures that for the RDSInstance resource of the postgres composition, the connection secret namespace will also be patched in.  Without this, the connection secret namespace is empty, which is an error because it is a required field.

Fixes #43 

Tested in UbC by creating a Network resource, then a PostgreSQLInstance resource and ensuring they both become Green and Ready.