### PR TITLE
update apiVersion

### DIFF
--- a/network/composition.yaml
+++ b/network/composition.yaml
@@ -132,7 +132,7 @@ spec:
               string:
                 fmt: "kubernetes.io/cluster/%s"
     - base:
-        apiVersion: ec2.aws.crossplane.io/v1alpha4
+        apiVersion: ec2.aws.crossplane.io/v1beta1
         kind: RouteTable
         spec:
           forProvider:


### PR DESCRIPTION
Fixes APIVersion for RouteTable now to reflect newer provider versions. 

Fixes #49 

Signed-off-by: Steven Borrelli <steve@borrelli.org>

Tested by creating a network using `examples/network.yaml`. 

```
$ kubectl get network,compositenetwork,routetable
NAME                                            READY   CONNECTION-SECRET   AGE
network.aws.platformref.crossplane.io/network   True                        112s

NAME                                                           READY   COMPOSITION                                       AGE
compositenetwork.aws.platformref.crossplane.io/network-7qgms   True    compositenetworks.aws.platformref.crossplane.io   112s

NAME                                                   READY   SYNCED   ID                      VPC                     AGE
routetable.ec2.aws.crossplane.io/network-7qgms-fkr4p   True    True     rtb-03845ac6d12449e2e   vpc-08750e7a040c90f33   110s
```