### PR TITLE
feat(oidc): tocompositefieldpath with OpenIDConnectProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ rm /usr/local/bin/kubectl-crossplane*
     * `NodeGroup`
     * `IAMRole`
     * `IAMRolePolicyAttachment`
+    * `OpenIDConnectProvider`
     * `HelmReleases` for Prometheus and other cluster services.
 * `Network` - fabric for a `Cluster` to securely connect to Data Services and
   the Internet.

--- a/cluster/eks/composition.yaml
+++ b/cluster/eks/composition.yaml
@@ -58,7 +58,7 @@ spec:
             resourcesVpcConfig:
               endpointPrivateAccess: true
               endpointPublicAccess: true
-            version: "1.16"
+            version: "1.21"
       patches:
         - fromFieldPath: metadata.annotations[crossplane.io/external-name]
           toFieldPath: metadata.annotations[crossplane.io/external-name]
@@ -74,6 +74,11 @@ spec:
           toFieldPath: spec.forProvider.resourcesVpcConfig.securityGroupIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
         - fromFieldPath: "spec.parameters.networkRef.id"
           toFieldPath: spec.forProvider.resourcesVpcConfig.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.identity.oidc.issuer
+          toFieldPath: status.eks.oidc
+          policy:
+            fromFieldPath: Optional
       connectionDetails:
         - fromConnectionSecretKey: kubeconfig
     - base:
@@ -167,6 +172,20 @@ spec:
                 large: t3.large
         - fromFieldPath: "spec.parameters.networkRef.id"
           toFieldPath: spec.forProvider.subnetSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
+    - base:
+        apiVersion: identity.aws.crossplane.io/v1alpha1
+        kind: OpenIDConnectProvider
+        spec:
+          forProvider:
+            clientIDList:
+              - sts.amazonaws.com
+            thumbprintList:
+              - "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
+      patches:
+        - fromFieldPath: status.eks.oidc
+          toFieldPath: spec.forProvider.url
+          policy:
+            fromFieldPath: Required
     - base:
         apiVersion: helm.crossplane.io/v1beta1
         kind: ProviderConfig

--- a/cluster/eks/definition.yaml
+++ b/cluster/eks/definition.yaml
@@ -59,3 +59,11 @@ spec:
                 - networkRef
             required:
             - parameters
+          status:
+            description: A Status represents the observed state
+            properties:
+              eks:
+                description: Freeform field containing status information for eks
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -90,6 +90,6 @@ spec:
     version: ">=v1.0.0-0"
   dependsOn:
     - provider: registry.upbound.io/crossplane/provider-aws
-      version: ">=v0.14.0-0"
+      version: ">=v0.19.0-0"
     - provider: registry.upbound.io/crossplane/provider-helm
       version: ">=v0.3.6-0"


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

### Description of your changes

- added patch toCompositeFieldPath for oidc issuer url 
- added OpenIDConnectProvider Resource to use the oidc issuer url
- changed eks version 1.16 to 1.21 because 1.16 is out of support 

Fixes parts of https://github.com/upbound/platform-ref-aws/issues/45

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

`kubectl apply -f examples/cluster.yaml`

```
kubectl get eks
NAME                                   READY   COMPOSITION                         AGE
platform-ref-aws-cluster-g2klb-vwlkn   True    eks.aws.platformref.crossplane.io   62m
```

```
Name:         platform-ref-aws-cluster-g2klb-vwlkn
Namespace:    
Labels:       crossplane.io/claim-name=platform-ref-aws-cluster
              crossplane.io/claim-namespace=api-service
              crossplane.io/composite=platform-ref-aws-cluster-g2klb
Annotations:  crossplane.io/external-name: platform-ref-aws-cluster
API Version:  aws.platformref.crossplane.io/v1alpha1
Kind:         EKS
Metadata:
  Creation Timestamp:  2021-10-30T11:33:16Z
  Generate Name:       platform-ref-aws-cluster-g2klb-
  Generation:          4
  Owner References:
    API Version:     aws.platformref.crossplane.io/v1alpha1
    Controller:      true
    Kind:            CompositeCluster
    Name:            platform-ref-aws-cluster-g2klb
    UID:             b7139690-3f2a-4964-90d2-5eae4cc30cfc
  Resource Version:  7787577
  Self Link:         /apis/aws.platformref.crossplane.io/v1alpha1/eks/platform-ref-aws-cluster-g2klb-vwlkn
  UID:               f01be1a0-2f42-4c08-9271-c0eebe8c9ac3
Spec:
  Composition Ref:
    Name:                     eks.aws.platformref.crossplane.io
  Composition Update Policy:  Automatic
  Id:                         platform-ref-aws-cluster
  Parameters:
    Network Ref:
      Id:  platform-ref-aws-network
    Nodes:
      Count:  3
      Size:   small
  Resource Refs:
    API Version:  identity.aws.crossplane.io/v1beta1
    Kind:         IAMRole
    Name:         platform-ref-aws-cluster-g2klb-2tjxq
    API Version:  identity.aws.crossplane.io/v1beta1
    Kind:         IAMRolePolicyAttachment
    Name:         platform-ref-aws-cluster-g2klb-ngqrz
    API Version:  eks.aws.crossplane.io/v1beta1
    Kind:         Cluster
    Name:         platform-ref-aws-cluster-g2klb-l7skc
    API Version:  identity.aws.crossplane.io/v1beta1
    Kind:         IAMRole
    Name:         platform-ref-aws-cluster-g2klb-68g6b
    API Version:  identity.aws.crossplane.io/v1beta1
    Kind:         IAMRolePolicyAttachment
    Name:         platform-ref-aws-cluster-g2klb-w64hv
    API Version:  identity.aws.crossplane.io/v1beta1
    Kind:         IAMRolePolicyAttachment
    Name:         platform-ref-aws-cluster-g2klb-qjgj6
    API Version:  identity.aws.crossplane.io/v1beta1
    Kind:         IAMRolePolicyAttachment
    Name:         platform-ref-aws-cluster-g2klb-m5xsf
    API Version:  eks.aws.crossplane.io/v1alpha1
    Kind:         NodeGroup
    Name:         platform-ref-aws-cluster-g2klb-2zjwq
    API Version:  identity.aws.crossplane.io/v1alpha1
    Kind:         OpenIDConnectProvider
    Name:         platform-ref-aws-cluster-g2klb-87dsq
  Write Connection Secret To Ref:
    Name:       b7139690-3f2a-4964-90d2-5eae4cc30cfc-eks
    Namespace:  upbound-system
Status:
  Conditions:
    Last Transition Time:  2021-10-30T12:31:31Z
    Reason:                Available
    Status:                True
    Type:                  Ready
  Connection Details:
    Last Published Time:  2021-10-30T12:35:34Z
  Eks:
    Oidc:  https://oidc.eks.us-west-2.amazonaws.com/id/4A468D686B1A4B1964C053F2870337C2

```

```
kubectl get OpenIDConnectProvider
NAME                                   READY   SYNCED   URL
platform-ref-aws-cluster-g2klb-87dsq   True    True     https://oidc.eks.us-west-2.amazonaws.com/id/4A468D686B1A4B1964C053F2870337C2
```

