### PR TITLE
Bump version in README to v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ There are two ways to run Universal Crossplane:
 1. Hosted on Upbound Cloud
 1. Self-hosted on any Kubernetes cluster.
 
-To provision the AWS Reference platform, you can pick the option that is best for you. 
+To provision the AWS Reference platform, you can pick the option that is best for you.
 
 We'll go through each option in the next sections.
 
@@ -141,7 +141,7 @@ cp kubectl-crossplane /usr/local/bin
 
 ```console
 # Check the latest version available in https://cloud.upbound.io/registry/upbound/platform-ref-aws
-PLATFORM_VERSION=v0.2.0
+PLATFORM_VERSION=v0.2.2
 PLATFORM_CONFIG=registry.upbound.io/upbound/platform-ref-aws:${PLATFORM_VERSION}
 
 kubectl crossplane install configuration ${PLATFORM_CONFIG}
@@ -304,7 +304,7 @@ Set these to match your settings:
 UPBOUND_ORG=acme
 UPBOUND_ACCOUNT_EMAIL=me@acme.io
 REPO=platform-ref-aws
-VERSION_TAG=v0.2.0
+VERSION_TAG=v0.2.2
 REGISTRY=registry.upbound.io
 PLATFORM_CONFIG=${REGISTRY:+$REGISTRY/}${UPBOUND_ORG}/${REPO}:${VERSION_TAG}
 ```
@@ -325,7 +325,7 @@ docker login ${REGISTRY} -u ${UPBOUND_ACCOUNT_EMAIL}
 Build package.
 
 ```console
-up xpkg build --name package.xpkg --ignore ".github/workflows/*,examples/*,hack/*" 
+up xpkg build --name package.xpkg --ignore ".github/workflows/*,examples/*,hack/*"
 ```
 
 Push package to registry.


### PR DESCRIPTION
### Description of your changes

This PR simply bumps the version of this reference platform package in the README to its latest released version: v0.2.2

https://github.com/upbound/platform-ref-aws/releases/tag/v0.2.2

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Walking through the readme steps and did sanity verification for installation.