### PR TITLE
Composition resource names

### DIFF
--- a/cluster/composition.yaml
+++ b/cluster/composition.yaml
@@ -13,6 +13,7 @@ spec:
         kind: EKS
       connectionDetails:
         - fromConnectionSecretKey: kubeconfig
+      name: compositeClusterEKS
       patches:
         - fromFieldPath: spec.id
           toFieldPath: spec.id
@@ -35,6 +36,7 @@ spec:
     - base:
         apiVersion: aws.platformref.crossplane.io/v1alpha1
         kind: Services
+      name: compositeClusterServices
       patches:
         - fromFieldPath: spec.id
           toFieldPath: spec.providerConfigRef.name

--- a/cluster/eks/composition.yaml
+++ b/cluster/eks/composition.yaml
@@ -35,6 +35,7 @@ spec:
                     }
                 ]
               }
+      name: controlplaneRole
     - base:
         apiVersion: iam.aws.crossplane.io/v1beta1
         kind: RolePolicyAttachment
@@ -45,6 +46,7 @@ spec:
               matchControllerRef: true
               matchLabels:
                 role: controlplane
+      name: clusterRolePolicyAttachment
     - base:
         apiVersion: eks.aws.crossplane.io/v1beta1
         kind: Cluster
@@ -59,6 +61,7 @@ spec:
               endpointPrivateAccess: true
               endpointPublicAccess: true
             version: "1.21"
+      name: kubernetesCluster
       patches:
         - fromFieldPath: metadata.annotations[crossplane.io/external-name]
           toFieldPath: metadata.annotations[crossplane.io/external-name]
@@ -106,6 +109,7 @@ spec:
                     }
                 ]
               }
+      name: nodegroupRole
     - base:
         apiVersion: iam.aws.crossplane.io/v1beta1
         kind: RolePolicyAttachment
@@ -116,6 +120,7 @@ spec:
               matchControllerRef: true
               matchLabels:
                 role: nodegroup
+      name: workerNodeRolePolicyAttachment
     - base:
         apiVersion: iam.aws.crossplane.io/v1beta1
         kind: RolePolicyAttachment
@@ -126,6 +131,7 @@ spec:
               matchControllerRef: true
               matchLabels:
                 role: nodegroup
+      name: cniRolePolicyAttachment
     - base:
         apiVersion: iam.aws.crossplane.io/v1beta1
         kind: RolePolicyAttachment
@@ -136,6 +142,7 @@ spec:
               matchControllerRef: true
               matchLabels:
                 role: nodegroup
+      name: containerRegistryRolePolicyAttachment
     - base:
         apiVersion: eks.aws.crossplane.io/v1alpha1
         kind: NodeGroup
@@ -157,6 +164,7 @@ spec:
               desiredSize: 1
             instanceTypes:
               - t3.medium
+      name: nodeGroupPublic
       patches:
         - fromFieldPath: metadata.annotations[crossplane.io/external-name]
           toFieldPath: metadata.annotations[crossplane.io/external-name]
@@ -181,6 +189,7 @@ spec:
               - sts.amazonaws.com
             thumbprintList:
               - "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
+      name: oidcProvider
       patches:
         - fromFieldPath: status.eks.oidc
           toFieldPath: spec.forProvider.url
@@ -194,6 +203,7 @@ spec:
             source: Secret
             secretRef:
               key: kubeconfig
+      name: providerConfig
       patches:
         - fromFieldPath: spec.id
           toFieldPath: metadata.name

--- a/cluster/services/composition.yaml
+++ b/cluster/services/composition.yaml
@@ -25,6 +25,7 @@ spec:
               repository: https://prometheus-community.github.io/helm-charts
               version: "10.1.0"
             values: {}
+      name: releasePrometheus
       patches:
         # All Helm releases derive their labels and annotations from the XR.
         - fromFieldPath: metadata.labels

--- a/database/postgres/composition.yaml
+++ b/database/postgres/composition.yaml
@@ -18,6 +18,7 @@ spec:
             region: us-west-2
             description: An excellent formation of subnetworks.
           deletionPolicy: Delete
+      name: compositePostgreSQLInstanceDbSubnetGroup
       patches:
         - fromFieldPath: "spec.parameters.networkRef.id"
           toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.crossplane.io/network-id]
@@ -36,6 +37,7 @@ spec:
             skipFinalSnapshotBeforeDeletion: true
             publiclyAccessible: false
           deletionPolicy: Delete
+      name: RDSInstanceSmall
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"

--- a/network/composition.yaml
+++ b/network/composition.yaml
@@ -30,6 +30,7 @@ spec:
               value: Platform Team
             - key: Name
               value: platformref-vpc
+      name: platformref-vcp
       patches:
         - type: PatchSet
           patchSetName: network-id
@@ -41,6 +42,7 @@ spec:
             region: us-west-2
             vpcIdSelector:
               matchControllerRef: true
+      name: gateway
       patches:
         - type: PatchSet
           patchSetName: network-id
@@ -61,7 +63,8 @@ spec:
             availabilityZone: us-west-2a
             tags:
               - key: kubernetes.io/role/elb
-                value: "1"
+                value: ""
+      name: subnet-public-west-2a
       patches:
         - type: PatchSet
           patchSetName: network-id
@@ -83,6 +86,7 @@ spec:
             tags:
               - key: kubernetes.io/role/elb
                 value: "1"
+      name: subnet-public-west-2b
       patches:
         - type: PatchSet
           patchSetName: network-id
@@ -105,6 +109,7 @@ spec:
                 key: ""
               - key: kubernetes.io/role/internal-elb
                 value: "1"
+      name: subnet-private-west-2a
       patches:
         - type: PatchSet
           patchSetName: network-id
@@ -133,6 +138,7 @@ spec:
                 key: ""
               - key: kubernetes.io/role/internal-elb
                 value: "1"
+      name: subnet-private-west-2b
       patches:
         - type: PatchSet
           patchSetName: network-id
@@ -175,6 +181,7 @@ spec:
                   matchLabels:
                     zone: us-west-2b
                     access: private
+      name: routeTable
       patches:
         - type: PatchSet
           patchSetName: network-id
@@ -195,6 +202,7 @@ spec:
                 ipRanges:
                   - cidrIp: 0.0.0.0/0
                     description: Everywhere
+      name: securityGroup
       patches:
         - type: PatchSet
           patchSetName: network-id

--- a/network/composition.yaml
+++ b/network/composition.yaml
@@ -63,7 +63,7 @@ spec:
             availabilityZone: us-west-2a
             tags:
               - key: kubernetes.io/role/elb
-                value: ""
+                value: "1"
       name: subnet-public-west-2a
       patches:
         - type: PatchSet


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Adding names to all the compositions resources. Inspired by a comment from @ytsarev https://github.com/upbound/platform-ref-aws/issues/45#issuecomment-1066699067.

The recommendation in the composition resource: At the same time, we are recommending it here
https://doc.crds.dev/github.com/crossplane/crossplane/apiextensions.crossplane.io/Composition/v1@v1.6.4#spec-resources-name

> A Name uniquely identifies this entry within its Composition's resources array. Names are optional but strongly recommended. When all entries in the resources array are named entries may added, deleted, and reordered as long as their names do not change. When entries are not named the length and order of the resources array should be treated as immutable. Either all or no entries must be named.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

I have:

- [x ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

To ensure that each `base` object has a correctponding `name` key, the following command was used:

```bash
cat */composition.yaml |  yq '.spec.resources[] | has("base")' | wc --words
cat */composition.yaml |  yq '.spec.resources[] | has("name")' | wc --words
```

The expected result is that the values match.

Additionally, all the resources were generated manually from the example folder and all were present and healthy in AWS.