### PR TITLE
Add docker buildx version to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
   workflow_dispatch: {}
 
 env:
+  DOCKER_BUILDX_VERSION: 'v0.8.2'
+
   XPKG_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}
 
 jobs:


### PR DESCRIPTION
### Description of your changes

Currently publish step fails with the following:

```
Run make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}
  
0[6](https://github.com/upbound/platform-ref-aws/actions/runs/3187775166/jobs/5199789961#step:9:6):47:22 [ .. ] Pushing package xpkg.upbound.io/upbound/platform-ref-aws:v0.5.0-rc.0.5.g[6](https://github.com/upbound/platform-ref-aws/actions/runs/3187775166/jobs/5199789961#step:9:7)a1[7](https://github.com/upbound/platform-ref-aws/actions/runs/3187775166/jobs/5199789961#step:9:8)e74
up: error: stream error: stream ID 29; PROTOCOL_ERROR; received from peer
06:47:23 [FAIL]
make[1]: *** [build/makelib/xpkg.mk:[9](https://github.com/upbound/platform-ref-aws/actions/runs/3187775166/jobs/5199789961#step:9:10)7: xpkg.release.publish.xpkg.upbound.io/upbound.platform-ref-aws] Error 1
make: *** [build/makelib/common.mk:402: publish] Error 2
```

Comparing with [provider-helm CI workflow](https://github.com/crossplane-contrib/provider-helm/blob/master/.github/workflows/ci.yml), this seems to be the culprit.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

To be tested with CI after merge.
