### PR TITLE
Bump kube-prometheus-stack chart to latest

### DIFF
--- a/package/cluster/services/composition.yaml
+++ b/package/cluster/services/composition.yaml
@@ -23,7 +23,7 @@ spec:
               # Note that default values are overridden by the patches below.
               name: kube-prometheus-stack
               repository: https://prometheus-community.github.io/helm-charts
-              version: "10.1.0"
+              version: "41.4.1"
             values: {}
       name: releasePrometheus
       patches:


### PR DESCRIPTION
### Description of your changes

Pushes kube-prometheus-stack chart to the latest version.
Also testing new e2e workflow.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

With e2e workflow.
