### PR TITLE
Reuse uptest workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,4 +9,3 @@ jobs:
     uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@main
     secrets:
       UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}
-      UPTEST_DATASOURCE: 'N/A'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,4 +9,4 @@ jobs:
     uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@main
     secrets:
       UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}
-      UPTEST_DATASOURCE: ${{ secrets.UPTEST_DATASOURCE }}
+      UPTEST_DATASOURCE: 'N/A'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,116 +1,12 @@
-name: End to End Test
+name: End to End Testing
 
 on:
   issue_comment:
     types: [created]
 
-env:
-  UPTEST_AWS_CREDS: ${{ secrets.UPTEST_AWS_CREDS }}
-
 jobs:
-  check-triggered:
-    runs-on: ubuntu-22.04
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/test-e2e') }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Checkout PR
-        id: checkout-pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr checkout ${{ github.event.issue.number }}
-          git submodule update --init --recursive
-          OUTPUT=$(git log -1 --format='%H')
-          echo "::set-output name=commit-sha::$OUTPUT"
-
-      - name: Create Pending Status Check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            /repos/${{ github.repository }}/statuses/${{ steps.checkout-pr.outputs.commit-sha }} \
-            -f state='pending' \
-            -f target_url='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
-            -f description='Running...' \
-            -f context="E2E"
-
   e2e:
-    runs-on: ubuntu-22.04
-    needs: check-triggered
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/test-e2e') }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Checkout PR
-        id: checkout-pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr checkout ${{ github.event.issue.number }}
-          git submodule update --init --recursive
-          OUTPUT=$(git log -1 --format='%H')
-          echo "::set-output name=commit-sha::$OUTPUT"
-
-      - name: Fetch History
-        run: git fetch --prune --unshallow
-
-      - name: End to end
-        run: make e2e
-        env:
-          UPTEST_AWS_CREDS: ${{ secrets.UPTEST_AWS_CREDS }}
-          UPTEST_TEST_DIR: ./_output/controlplane-dump
-
-      - name: Create Successful Status Check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            /repos/${{ github.repository }}/statuses/${{ steps.checkout-pr.outputs.commit-sha }} \
-            -f state='success' \
-            -f target_url='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
-            -f description='Passed' \
-            -f context="E2E"
-
-      - name: Collect Cluster Dump
-        if: always()
-        run: |
-          export CONTROLPLANE_DUMP_DIRECTORY=./_output/controlplane-dump
-          make controlplane.dump
-
-      - name: Upload Cluster Dump
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: cluster-dump
-          path: ./_output/controlplane-dump
-
-      - name: Cleanup
-        if: always()
-        run: |
-          eval $(make --no-print-directory build.vars)
-          ${KUBECTL} delete managed --all
-
-      - name: Create Unsuccessful Status Check
-        if: failure()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            /repos/${{ github.repository }}/statuses/${{ steps.checkout-pr.outputs.commit-sha }} \
-            -f state='failure' \
-            -f target_url='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
-            -f description='Failed' \
-            -f context="E2E"
+    uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@main
+    secrets:
+      UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}
+      UPTEST_DATASOURCE: ${{ secrets.UPTEST_DATASOURCE }}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PLATFORMS ?= linux_amd64
 
 UP_VERSION = v0.13.0
 UP_CHANNEL = stable
-UPTEST_VERSION = v0.1.1
+UPTEST_VERSION = v0.2.1
 
 -include build/makelib/k8s_tools.mk
 # ====================================================================================
@@ -54,9 +54,16 @@ build.init: $(UP)
 
 # ====================================================================================
 # End to End Testing
-uptest: build $(UPTEST) $(KUBECTL) $(KUTTL) local.xpkg.deploy.configuration.$(PROJECT_NAME)
+
+# This target requires the following environment variables to be set:
+# - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat ~/.aws/credentials)
+uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
 	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) $(UPTEST) e2e examples/cluster-claim.yaml --setup-script=test/setup.sh --default-timeout=2400 || $(FAIL)
 	@$(OK) running automated tests
 
-e2e: controlplane.up uptest
+# This target requires the following environment variables to be set:
+# - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat ~/.aws/credentials)
+e2e: build controlplane.up local.xpkg.deploy.configuration.$(PROJECT_NAME) uptest
+
+.PHONY: uptest e2e

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -7,7 +7,7 @@ ${KUBECTL} wait configuration.pkg platform-ref-aws --for=condition=Healthy --tim
 ${KUBECTL} wait configuration.pkg platform-ref-aws --for=condition=Installed --timeout 5m
 
 echo "Creating cloud credential secret..."
-${KUBECTL} -n upbound-system create secret generic aws-creds --from-literal=credentials="${UPTEST_AWS_CREDS}" \
+${KUBECTL} -n upbound-system create secret generic aws-creds --from-literal=credentials="${UPTEST_CLOUD_CREDENTIALS}" \
     --dry-run=client -o yaml | ${KUBECTL} apply -f -
 
 echo "Waiting until provider-aws is healthy..."


### PR DESCRIPTION
### Description of your changes

Consumes reusable workflows introduced in https://github.com/upbound/uptest/pull/39
Also, standardize Makefile targets.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
export UPTEST_CLOUD_CREDENTIALS=$(cat ~/.aws/credentials)
make e2e
```

Validated workflow changes with https://github.com/upbound/provider-aws/pull/116
