### PR TITLE
Fix security group selector for rds instance

### DIFF
--- a/package/database/postgres/composition.yaml
+++ b/package/database/postgres/composition.yaml
@@ -50,7 +50,7 @@ spec:
         - fromFieldPath: spec.parameters.storageGB
           toFieldPath: spec.forProvider.allocatedStorage
         - fromFieldPath: spec.parameters.clusterRef.id
-          toFieldPath: spec.forProvider.vpcSecurityGroupIDSelector.matchLabels[networks.aws.platformref.upbound.io/network-id]
+          toFieldPath: spec.forProvider.vpcSecurityGroupIdSelector.matchLabels[networks.aws.platformref.upbound.io/network-id]
         - fromFieldPath: spec.parameters.passwordSecretRef.namespace
           toFieldPath: spec.forProvider.passwordSecretRef.namespace
         - fromFieldPath: spec.parameters.passwordSecretRef.name


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* ID vs Id again :(
* Without it 5432 port is not getting open and the database is not accessible

Signed-off-by: Yury Tsarev <yury@upbound.io>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
 k apply -f examples/cluster-claim.yaml
 k apply -f examples/postgres-claim.yaml

# switch context to deployed eks cluster by the claim 

cat psql.yaml
apiVersion: v1
kind: Pod
metadata:
  name: see-db
  namespace: default
spec:
  containers:
  - name: see-db
    image: postgres:12
    command: ['psql']
    args: ['-c', 'SELECT current_database();']
    env:
    - name: PGDATABASE
      value: postgres
    - name: PGHOST
      value: platform-ref-aws-db-tpgdx-jbx72.cxal1lomznba.us-west-2.rds.amazonaws.com
    - name: PGUSER
      value: masteruser
    - name: PGPASSWORD
      value: <password>

k logs -f see-db
 current_database
------------------
 postgres
(1 row)
```
