### PR TITLE
Introduce SQLClaim that can handle any RDS database engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ Create a custom defined database:
 kubectl apply -f examples/postgres-claim.yaml
 ```
 
+**NOTE**: Database abstraction is relying on Cluster claim to be ready as it is
+using the same network to have the connectivity with EKS cluster.
+
+Alternatively, you can use mariadb claim:
+
+```
+kubectl apply -f examples/mariadb-claim.yaml
+```
+
 You can verify status by inspecting the claims, composites and managed
 resources:
 

--- a/examples/mariadb-claim.yaml
+++ b/examples/mariadb-claim.yaml
@@ -9,7 +9,7 @@ spec:
     storageGB: 5
     passwordSecretRef:
       namespace: default
-      name: psqlsecret
+      name: mariadbsecret
       key: password
     clusterRef:
       id: platform-ref-aws
@@ -21,6 +21,6 @@ data:
   password: dXBiMHVuZHIwY2s1ITMxMzM3
 kind: Secret
 metadata:
-  name: psqlsecret
+  name: mariadbsecret
   namespace: default
 type: Opaque

--- a/examples/mariadb-claim.yaml
+++ b/examples/mariadb-claim.yaml
@@ -1,11 +1,11 @@
 apiVersion: aws.platformref.upbound.io/v1alpha1
 kind: SQLInstance
 metadata:
-  name: platform-ref-aws-db-postgres
+  name: platform-ref-aws-db-mariadb
 spec:
   parameters:
-    engine: postgres
-    engineVersion: "13.7"
+    engine: mariadb
+    engineVersion: "10.6.10"
     storageGB: 5
     passwordSecretRef:
       namespace: default
@@ -14,7 +14,7 @@ spec:
     clusterRef:
       id: platform-ref-aws
   writeConnectionSecretToRef:
-    name: platform-ref-aws-db-conn-postgres
+    name: platform-ref-aws-db-conn-mariadb
 ---
 apiVersion: v1
 data:

--- a/package/cluster/network/composition.yaml
+++ b/package/cluster/network/composition.yaml
@@ -247,7 +247,8 @@ spec:
       patches:
         - type: PatchSet
           patchSetName: network-id
-    - base:
+    - name: securityGroup
+      base:
         apiVersion: ec2.aws.upbound.io/v1beta1
         kind: SecurityGroup
         spec:
@@ -256,15 +257,15 @@ spec:
             vpcIdSelector:
               matchControllerRef: true
             name: platform-ref-aws-cluster
-            description: Allow access to PostgreSQL
-      name: securityGroup
+            description: Allow access to databases
       patches:
         - type: PatchSet
           patchSetName: network-id
         - type: ToCompositeFieldPath
           fromFieldPath: metadata.annotations[crossplane.io/external-name]
           toFieldPath: status.securityGroupIds[0]
-    - base:
+    - name: securityGroupRulePostgres
+      base:
         apiVersion: ec2.aws.upbound.io/v1beta1
         kind: SecurityGroupRule
         spec:
@@ -279,7 +280,25 @@ spec:
             securityGroupIdSelector:
               matchControllerRef: true
             description: Everywhere
-      name: securityGroupRule
+      patches:
+        - type: PatchSet
+          patchSetName: network-id
+    - name: securityGroupRuleMysql
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroupRule
+        spec:
+          forProvider:
+            region: us-west-2
+            type: ingress
+            fromPort: 3306
+            toPort: 3306
+            protocol: tcp
+            cidrBlocks:
+              - 0.0.0.0/0
+            securityGroupIdSelector:
+              matchControllerRef: true
+            description: Everywhere
       patches:
         - type: PatchSet
           patchSetName: network-id

--- a/package/database/postgres/composition.yaml
+++ b/package/database/postgres/composition.yaml
@@ -1,16 +1,17 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xpostgresqlinstances.aws.platformref.upbound.io
+  name: xsqlinstances.aws.platformref.upbound.io
   labels:
     provider: aws
 spec:
   writeConnectionSecretsToNamespace: upbound-system
   compositeTypeRef:
     apiVersion: aws.platformref.upbound.io/v1alpha1
-    kind: XPostgreSQLInstance
+    kind: XSQLInstance
   resources:
-    - base:
+    - name: compositeSQLInstanceDbSubnetGroup
+      base:
         apiVersion: rds.aws.upbound.io/v1beta1
         kind: SubnetGroup
         spec:
@@ -18,11 +19,11 @@ spec:
             region: us-west-2
             description: An excellent formation of subnetworks.
           deletionPolicy: Delete
-      name: compositePostgreSQLInstanceDbSubnetGroup
       patches:
         - fromFieldPath: spec.parameters.clusterRef.id
           toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.upbound.io/network-id]
-    - base:
+    - name: RDSInstanceSmall
+      base:
         apiVersion: rds.aws.upbound.io/v1beta1
         kind: Instance
         spec:
@@ -32,21 +33,22 @@ spec:
               matchControllerRef: true
             instanceClass: db.t3.micro
             username: masteruser
-            engine: postgres
-            engineVersion: "13.7"
             skipFinalSnapshot: true
             publiclyAccessible: false
           deletionPolicy: Delete
-      name: RDSInstanceSmall
       patches:
         - fromFieldPath: "metadata.uid"
           toFieldPath: "spec.writeConnectionSecretToRef.name"
           transforms:
             - type: string
               string:
-                fmt: "%s-postgresql"
+                fmt: "%s-sql" #change
         - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - fromFieldPath: spec.parameters.engine
+          toFieldPath: spec.forProvider.engine
+        - fromFieldPath: spec.parameters.engineVersion
+          toFieldPath: spec.forProvider.engineVersion
         - fromFieldPath: spec.parameters.storageGB
           toFieldPath: spec.forProvider.allocatedStorage
         - fromFieldPath: spec.parameters.clusterRef.id

--- a/package/database/postgres/definition.yaml
+++ b/package/database/postgres/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xpostgresqlinstances.aws.platformref.upbound.io
+  name: xsqlinstances.aws.platformref.upbound.io
 spec:
   claimNames:
-    kind: PostgreSQLInstance
-    plural: postgresqlinstances
+    kind: SQLInstance
+    plural: sqlinstances
   connectionSecretKeys:
     - username
     - password
@@ -13,8 +13,8 @@ spec:
     - port
   group: aws.platformref.upbound.io
   names:
-    kind: XPostgreSQLInstance
-    plural: xpostgresqlinstances
+    kind: XSQLInstance
+    plural: xsqlinstances
   versions:
   - name: v1alpha1
     served: true
@@ -29,6 +29,12 @@ spec:
               parameters:
                 type: object
                 properties:
+                  engine:
+                    type: string
+                    description: This RDS Instance engine, see https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html for possible values.
+                  engineVersion:
+                    type: string
+                    description: This RDS Instance engine version, see https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html for possible values.
                   storageGB:
                     type: integer
                   passwordSecretRef:
@@ -47,8 +53,7 @@ spec:
                     - key
                   clusterRef:
                     type: object
-                    description: "A reference to the Network object that this postgres should be
-                    connected to."
+                    description: "A reference to the Network object that this database should be connected to."
                     properties:
                       id:
                         type: string
@@ -56,6 +61,8 @@ spec:
                     required:
                     - id
                 required:
+                  - engine
+                  - engineVersion
                   - storageGB
                   - clusterRef
                   - passwordSecretRef

--- a/package/database/sqlinstance/composition.yaml
+++ b/package/database/sqlinstance/composition.yaml
@@ -35,6 +35,7 @@ spec:
             username: masteruser
             skipFinalSnapshot: true
             publiclyAccessible: false
+            dbName: upbound # create custom database within the instance by default
           deletionPolicy: Delete
       patches:
         - fromFieldPath: "metadata.uid"

--- a/package/database/sqlinstance/definition.yaml
+++ b/package/database/sqlinstance/definition.yaml
@@ -32,6 +32,9 @@ spec:
                   engine:
                     type: string
                     description: This RDS Instance engine, see https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html for possible values.
+                    enum:
+                    - postgres
+                    - mariadb
                   engineVersion:
                     type: string
                     description: This RDS Instance engine version, see https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html for possible values.


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Instead of hardcoded PostgreSQL, make generic SQL XRD/Composition that can handle arbitrary RDS instance engine configuration

* PostgrSQLInstance -> SQLInstance
* expose `engine` and `engineVersion` in XRD
* Add 3306 SecurityGroupRule
* Provide mariadb example

Signed-off-by: Yury Tsarev <yury@upbound.io>


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
k apply -f examples/cluster-claim.yaml,examples/postgres-claim.yaml,examples/mariadb-claim.yaml
```

PostgreSQL connectivity test from within instantiated EKS cluster
```
cat psql.yaml
apiVersion: v1
kind: Pod
metadata:
  name: see-db
  namespace: default
spec:
  containers:
  - name: see-db
    image: postgres:12
    command: ['psql']
    args: ['-c', 'SELECT current_database();']
    env:
    - name: PGDATABASE
      value: postgres
    - name: PGHOST
      value: platform-ref-aws-db-postgres-t5jnc-hgktq.cxal1lomznba.us-west-2.rds.amazonaws.com
    - name: PGUSER
      value: masteruser
    - name: PGPASSWORD
      value: <password>

k logs -f see-db
 current_database
------------------
 postgres
(1 row)
```

mariadb connectivity test from within instantiated EKS cluster
```
kubectl run -i --tty --rm debug --image=mysql --restart=Never -- sh
sh-4.4# mysql -h platform-ref-aws-db-mariadb-grpz9-92kzs.cxal1lomznba.us-west-2.rds.amazonaws.com -u masteruser -p
Enter password:
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 79
Server version: 5.5.5-10.6.10-MariaDB managed by https://aws.amazon.com/rds/

Copyright (c) 2000, 2022, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show databases
    -> ;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| innodb             |
| mysql              |
| performance_schema |
| sys                |
+--------------------+
5 rows in set (0.00 sec)
```
