### PR TITLE
Add EBS CSI driver for EKS

### DIFF
--- a/package/cluster/eks/composition.yaml
+++ b/package/cluster/eks/composition.yaml
@@ -207,6 +207,7 @@ spec:
             crossplane.io/external-name: aws-ebs-csi-driver
         spec:
           forProvider:
+            addonName: aws-ebs-csi-driver
             clusterNameSelector:
               matchControllerRef: true
             region: us-west-2

--- a/package/cluster/eks/composition.yaml
+++ b/package/cluster/eks/composition.yaml
@@ -147,6 +147,17 @@ spec:
         kind: RolePolicyAttachment
         spec:
           forProvider:
+            policyArn: arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+            roleSelector:
+              matchControllerRef: true
+              matchLabels:
+                role: nodegroup
+      name: ebsCsiRolePolicyAttachment
+    - base:
+        apiVersion: iam.aws.upbound.io/v1beta1
+        kind: RolePolicyAttachment
+        spec:
+          forProvider:
             policyArn: arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
             roleSelector:
               matchControllerRef: true
@@ -188,6 +199,18 @@ spec:
                 large: t3.large
         - fromFieldPath: spec.id
           toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.upbound.io/network-id]
+    - base:
+        apiVersion: eks.aws.upbound.io/v1beta1
+        kind: Addon
+        metadata:
+          annotations:
+            crossplane.io/external-name: aws-ebs-csi-driver
+        spec:
+          forProvider:
+            clusterNameSelector:
+              matchControllerRef: true
+            region: us-west-2
+      name: ebsCsiAddon
     - base:
         apiVersion: iam.aws.upbound.io/v1beta1
         kind: OpenIDConnectProvider


### PR DESCRIPTION
Without the EBS CSI driver, the default `StorageClass` is no longer sufficient on recent EKS - persistent volumes cannot be provisioned. 

### Description of your changes

This change adds the EBS "Addon" for EKS and attaches the default AWS Policy for EBS CSI Driver to the cluster's nodegroup. Note: this just one of the ways it can be done, but others are not as straightforward to implement currently. A safer way would be to use IRSA, but that has not yet been implemented (see #85)

Ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/install.md

Fixes #96

### How has this code been tested

- Created a cluster with modified `xeks.aws.platformref.upbound.io` composition
- Was able to trigger PV creation through PVC in the provisioned EKS cluster.