### PR TITLE
Fix uptest deletion stuck

### DIFF
--- a/examples/cluster-claim.yaml
+++ b/examples/cluster-claim.yaml
@@ -4,7 +4,7 @@ metadata:
   name: platform-ref-aws
   namespace: default
   annotations:
-    uptest.upbound.io/post-assert-hook: testhooks/delete-release.sh
+    uptest.upbound.io/pre-delete-hook: testhooks/delete-release.sh
 spec:
   id: platform-ref-aws
   parameters:

--- a/examples/testhooks/delete-release.sh
+++ b/examples/testhooks/delete-release.sh
@@ -3,4 +3,7 @@ set -aeuo pipefail
 
 # Delete the release before deleting the cluster not to orphan the release object
 # Note(turkenh): This is a workaround for the infamous dependency problem during deletion.
+# Note(ytsarev): In addition to helm Release deletion we also need to pause
+# XService reconciler to prevent it from recreating the Release.
+${KUBECTL} annotate xservices.aws.platformref.upbound.io --all crossplane.io/paused="true"
 ${KUBECTL} delete release --all


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

The uptest run was stuck indefinitely while waiting for Release cleanup due to Release recreation by associated XServices XR right after the original cleanup

* Switch to the proper pre-delete-hook
* Stop XService reconciliation in the hook to avoid Release recreation after hook-based cleanup


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
make e2e
```
