### PR TITLE
Bump the referenced platform-ref-aws version in README.md to v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ configuration package](https://crossplane.io/docs/v1.10/concepts/packages.html)
 so there is a single command to install it:
 
 ```console
-up ctp configuration install xpkg.upbound.io/upbound/platform-ref-aws:v0.5.0
+up ctp configuration install xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
 ```
 
 Validate the install by inspecting the provider and configuration packages:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->
Bumps the referenced platform ref version in the `README.md` file from `v0.5.0` to `v0.6.0` so that the installed configuration package will depend of the family providers instead of the monolith.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
Manually tested just past the configuration package install step.