### PR TITLE
Add ability to set uxp and eks version

### DIFF
--- a/examples/cluster-claim.yaml
+++ b/examples/cluster-claim.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   id: platform-ref-aws
   parameters:
+    version: "1.26"
     nodes:
       count: 3
       size: small
@@ -15,5 +16,7 @@ spec:
       operators:
         prometheus:
           version: "34.5.1"
+        universal-crossplane:
+          version: "1.12.1-up.1"
   writeConnectionSecretToRef:
     name: platform-ref-aws-kubeconfig

--- a/examples/cluster-claim.yaml
+++ b/examples/cluster-claim.yaml
@@ -17,6 +17,6 @@ spec:
         prometheus:
           version: "34.5.1"
         universal-crossplane:
-          version: "1.12.1-up.1"
+          version: "1.12.2-up.1"
   writeConnectionSecretToRef:
     name: platform-ref-aws-kubeconfig

--- a/package/cluster/composition.yaml
+++ b/package/cluster/composition.yaml
@@ -44,6 +44,8 @@ spec:
                 fmt: "%s-eks"
         - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - fromFieldPath: spec.parameters.version
+          toFieldPath: spec.parameters.version
         - fromFieldPath: spec.parameters.nodes.count
           toFieldPath: spec.parameters.nodes.count
         - fromFieldPath: spec.parameters.nodes.size
@@ -65,3 +67,5 @@ spec:
           toFieldPath: spec.providerConfigRef.name
         - fromFieldPath: spec.parameters.services.operators.prometheus.version
           toFieldPath: spec.operators.prometheus.version
+        - fromFieldPath: spec.parameters.services.operators.universal-crossplane.version
+          toFieldPath: spec.operators.universal-crossplane.version

--- a/package/cluster/definition.yaml
+++ b/package/cluster/definition.yaml
@@ -30,6 +30,9 @@ spec:
                 type: object
                 description: Cluster configuration parameters.
                 properties:
+                  version:
+                    type: string
+                    description: Kubernetes version of the Cluster
                   nodes:
                     type: object
                     description: Cluster node configuration parameters.
@@ -62,6 +65,13 @@ spec:
                               version:
                                 type: string
                                 description: Prometheus operator version to run.
+                          universal-crossplane:
+                            type: object
+                            description: Configuration for Universal Crossplane (UXP)
+                            properties:
+                              version:
+                                type: string
+                                description: UXP Version  
                 required:
                 - nodes
             required:

--- a/package/cluster/eks/composition.yaml
+++ b/package/cluster/eks/composition.yaml
@@ -60,7 +60,6 @@ spec:
             vpcConfig:
               - endpointPrivateAccess: true
                 endpointPublicAccess: true
-            version: "1.23"
       name: kubernetesCluster
       patches:
           # Change to spec id
@@ -68,6 +67,8 @@ spec:
           toFieldPath: spec.forProvider.vpcConfig[0].securityGroupIds
         - fromFieldPath: spec.parameters.subnetIds
           toFieldPath: spec.forProvider.vpcConfig[0].subnetIds
+        - fromFieldPath: spec.parameters.version
+          toFieldPath: spec.forProvider.version
         - type: ToCompositeFieldPath
           fromFieldPath: status.atProvider.identity[0].oidc[0].issuer
           toFieldPath: status.eks.oidc

--- a/package/cluster/eks/definition.yaml
+++ b/package/cluster/eks/definition.yaml
@@ -27,6 +27,16 @@ spec:
                 type: object
                 description: EKS configuration parameters.
                 properties:
+                  version:
+                    description: Kubernetes version 
+                    type: string
+                    enum:
+                    - "1.27"
+                    - "1.26"
+                    - "1.25"
+                    - "1.24"
+                    - "1.23"
+                    default: "1.27"
                   subnetIds:
                     type: array
                     items:

--- a/package/cluster/services/composition.yaml
+++ b/package/cluster/services/composition.yaml
@@ -51,7 +51,6 @@ spec:
               # Note that default values are overridden by the patches below.
               name: universal-crossplane
               repository: https://charts.upbound.io/stable
-              version: "1.10.1-up.1"
             values: {}
       patches:
         # All Helm releases derive their labels and annotations from the XR.
@@ -62,3 +61,5 @@ spec:
         # All Helm releases derive the ProviderConfig to use from the XR.
         - fromFieldPath: spec.providerConfigRef.name
           toFieldPath: spec.providerConfigRef.name
+        - fromFieldPath: spec.operators.universal-crossplane.version
+          toFieldPath: spec.forProvider.chart.version

--- a/package/cluster/services/definition.yaml
+++ b/package/cluster/services/definition.yaml
@@ -29,6 +29,14 @@ spec:
                       version:
                         type: string
                         description: Prometheus operator version to run.
+                  universal-crossplane:
+                    type: object
+                    description: Configuration for Universal Crossplane (UXP)
+                    properties:
+                      version:
+                        type: string
+                        description: UXP Version. Default is 1.12.2-up.1
+                        default: 1.12.2-up.1
               providerConfigRef:
                 type: object
                 description: "A reference to the ProviderConfig of the cluster that services should


### PR DESCRIPTION
### Description of your changes

As part of testing various UXP onEKS it would be helpful to be able to configure cluster and UXP versions. In this change:

- Add ability to set the EKS and UXP version
- update UXP default to 1.12.2-up.1
- update EKS version to 1.27

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
