### PR TITLE
WIP: port to Crossplane Functions

### DIFF
--- a/package/app/composition.yaml
+++ b/package/app/composition.yaml
@@ -9,62 +9,70 @@ spec:
   compositeTypeRef:
     apiVersion: aws.platformref.upbound.io/v1alpha1
     kind: XApp
-  resources:
-    - name: helmRelease
-      base:
-        apiVersion: helm.crossplane.io/v1beta1
-        kind: Release
-        spec:
-          rollbackLimit: 3
-          forProvider:
-            namespace: ghost
-            chart:
-              name: ghost
-              repository: https://charts.bitnami.com/bitnami
-              version: "19.3.10"
-            values:
-              persistence:
-                enabled: false
-              mysql:
-                enabled: false
-              externalDatabase:
-                database: upbound
-                port: 3306
-              ghostHost: upboundrocks.cloud
-              ghostBlogTitle: Upbound Rocks!
-            set:
-              - name: externalDatabase.host
-                valueFrom:
-                  secretKeyRef:
-                    key: host
-              - name: externalDatabase.user
-                valueFrom:
-                  secretKeyRef:
-                    key: username
-              - name: externalDatabase.password
-                valueFrom:
-                  secretKeyRef:
-                    key: password
-      patches:
-        # All Helm releases derive their labels and annotations from the XR.
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        # All Helm releases derive the ProviderConfig to use from the XR.
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.helm.chart.version
-          toFieldPath: spec.forProvider.chart.version
-        - fromFieldPath: spec.passwordSecretRef.namespace
-          toFieldPath: spec.forProvider.set[0].valueFrom.secretKeyRef.namespace
-        - fromFieldPath: spec.passwordSecretRef.name
-          toFieldPath: spec.forProvider.set[0].valueFrom.secretKeyRef.name
-        - fromFieldPath: spec.passwordSecretRef.namespace
-          toFieldPath: spec.forProvider.set[1].valueFrom.secretKeyRef.namespace
-        - fromFieldPath: spec.passwordSecretRef.name
-          toFieldPath: spec.forProvider.set[1].valueFrom.secretKeyRef.name
-        - fromFieldPath: spec.passwordSecretRef.namespace
-          toFieldPath: spec.forProvider.set[2].valueFrom.secretKeyRef.namespace
-        - fromFieldPath: spec.passwordSecretRef.name
-          toFieldPath: spec.forProvider.set[2].valueFrom.secretKeyRef.name
+    mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+        - name: helmRelease
+          base:
+            apiVersion: helm.crossplane.io/v1beta1
+            kind: Release
+            spec:
+              rollbackLimit: 3
+              forProvider:
+                namespace: ghost
+                chart:
+                  name: ghost
+                  repository: https://charts.bitnami.com/bitnami
+                  version: "19.3.10"
+                values:
+                  persistence:
+                    enabled: false
+                  mysql:
+                    enabled: false
+                  externalDatabase:
+                    database: upbound
+                    port: 3306
+                  ghostHost: upboundrocks.cloud
+                  ghostBlogTitle: Upbound Rocks!
+                set:
+                  - name: externalDatabase.host
+                    valueFrom:
+                      secretKeyRef:
+                        key: host
+                  - name: externalDatabase.user
+                    valueFrom:
+                      secretKeyRef:
+                        key: username
+                  - name: externalDatabase.password
+                    valueFrom:
+                      secretKeyRef:
+                        key: password
+          patches:
+            # All Helm releases derive their labels and annotations from the XR.
+            - fromFieldPath: metadata.labels
+              toFieldPath: metadata.labels
+            - fromFieldPath: metadata.annotations
+              toFieldPath: metadata.annotations
+            # All Helm releases derive the ProviderConfig to use from the XR.
+            - fromFieldPath: spec.providerConfigRef.name
+              toFieldPath: spec.providerConfigRef.name
+            - fromFieldPath: spec.helm.chart.version
+              toFieldPath: spec.forProvider.chart.version
+            - fromFieldPath: spec.passwordSecretRef.namespace
+              toFieldPath: spec.forProvider.set[0].valueFrom.secretKeyRef.namespace
+            - fromFieldPath: spec.passwordSecretRef.name
+              toFieldPath: spec.forProvider.set[0].valueFrom.secretKeyRef.name
+            - fromFieldPath: spec.passwordSecretRef.namespace
+              toFieldPath: spec.forProvider.set[1].valueFrom.secretKeyRef.namespace
+            - fromFieldPath: spec.passwordSecretRef.name
+              toFieldPath: spec.forProvider.set[1].valueFrom.secretKeyRef.name
+            - fromFieldPath: spec.passwordSecretRef.namespace
+              toFieldPath: spec.forProvider.set[2].valueFrom.secretKeyRef.namespace
+            - fromFieldPath: spec.passwordSecretRef.name
+              toFieldPath: spec.forProvider.set[2].valueFrom.secretKeyRef.name

--- a/package/app/composition.yaml
+++ b/package/app/composition.yaml
@@ -9,11 +9,11 @@ spec:
   compositeTypeRef:
     apiVersion: aws.platformref.upbound.io/v1alpha1
     kind: XApp
-    mode: Pipeline
+  mode: Pipeline
   pipeline:
   - step: patch-and-transform
     functionRef:
-      name: function-patch-and-transform
+      name: crossplane-contrib-function-patch-and-transform
     input:
       apiVersion: pt.fn.crossplane.io/v1beta1
       kind: Resources

--- a/package/cluster/composition.yaml
+++ b/package/cluster/composition.yaml
@@ -7,67 +7,78 @@ spec:
   compositeTypeRef:
     apiVersion: aws.platformref.upbound.io/v1alpha1
     kind: XCluster
-  resources:
-    - base:
-        apiVersion: aws.platformref.upbound.io/v1alpha1
-        kind: XNetwork
-      patches:
-        - fromFieldPath: spec.id
-          toFieldPath: spec.id
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.subnetIds
-          toFieldPath: status.subnetIds
-          policy:
-            fromFieldPath: Required
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.securityGroupIds
-          toFieldPath: status.securityGroupIds
-          policy:
-            fromFieldPath: Required
-      name: compositeNetworkEKS
-    - base:
-        apiVersion: aws.platformref.upbound.io/v1alpha1
-        kind: XEKS
-      connectionDetails:
-        - fromConnectionSecretKey: kubeconfig
-      name: compositeClusterEKS
-      patches:
-        - fromFieldPath: spec.id
-          toFieldPath: spec.id
-        - fromFieldPath: spec.id
-          toFieldPath: metadata.annotations[crossplane.io/external-name]
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.writeConnectionSecretToRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-eks"
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: spec.parameters.version
-          toFieldPath: spec.parameters.version
-        - fromFieldPath: spec.parameters.nodes.count
-          toFieldPath: spec.parameters.nodes.count
-        - fromFieldPath: spec.parameters.nodes.size
-          toFieldPath: spec.parameters.nodes.size
-        - fromFieldPath: status.subnetIds
-          toFieldPath: spec.parameters.subnetIds
-          policy:
-            fromFieldPath: Required
-        - fromFieldPath: status.securityGroupIds
-          toFieldPath: spec.parameters.securityGroupIds
-          policy:
-            fromFieldPath: Required
-    - base:
-        apiVersion: aws.platformref.upbound.io/v1alpha1
-        kind: XServices
-      name: compositeClusterServices
-      patches:
-        - fromFieldPath: spec.id
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.services.operators.prometheus.version
-          toFieldPath: spec.operators.prometheus.version
-        - fromFieldPath: spec.parameters.services.operators.universal-crossplane.version
-          toFieldPath: spec.operators.universal-crossplane.version
-        - fromFieldPath: spec.id
-          toFieldPath: spec.operators.universal-crossplane.clusterRef
+  mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: crossplane-contrib-function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+        - base:
+            apiVersion: aws.platformref.upbound.io/v1alpha1
+            kind: XNetwork
+          patches:
+            - fromFieldPath: spec.id
+              toFieldPath: spec.id
+            - type: ToCompositeFieldPath
+              fromFieldPath: status.subnetIds
+              toFieldPath: status.subnetIds
+              policy:
+                fromFieldPath: Required
+            - type: ToCompositeFieldPath
+              fromFieldPath: status.securityGroupIds
+              toFieldPath: status.securityGroupIds
+              policy:
+                fromFieldPath: Required
+          name: compositeNetworkEKS
+        - base:
+            apiVersion: aws.platformref.upbound.io/v1alpha1
+            kind: XEKS
+          connectionDetails:
+            - fromConnectionSecretKey: kubeconfig
+              name: kubeconfig
+              type: FromConnectionSecretKey
+          name: compositeClusterEKS
+          patches:
+            - fromFieldPath: spec.id
+              toFieldPath: spec.id
+            - fromFieldPath: spec.id
+              toFieldPath: metadata.annotations[crossplane.io/external-name]
+            - fromFieldPath: metadata.uid
+              toFieldPath: spec.writeConnectionSecretToRef.name
+              transforms:
+                - type: string
+                  string:
+                    type: Format
+                    fmt: "%s-eks"
+            - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+              toFieldPath: spec.writeConnectionSecretToRef.namespace
+            - fromFieldPath: spec.parameters.version
+              toFieldPath: spec.parameters.version
+            - fromFieldPath: spec.parameters.nodes.count
+              toFieldPath: spec.parameters.nodes.count
+            - fromFieldPath: spec.parameters.nodes.size
+              toFieldPath: spec.parameters.nodes.size
+            - fromFieldPath: status.subnetIds
+              toFieldPath: spec.parameters.subnetIds
+              policy:
+                fromFieldPath: Required
+            - fromFieldPath: status.securityGroupIds
+              toFieldPath: spec.parameters.securityGroupIds
+              policy:
+                fromFieldPath: Required
+        - base:
+            apiVersion: aws.platformref.upbound.io/v1alpha1
+            kind: XServices
+          name: compositeClusterServices
+          patches:
+            - fromFieldPath: spec.id
+              toFieldPath: spec.providerConfigRef.name
+            - fromFieldPath: spec.parameters.services.operators.prometheus.version
+              toFieldPath: spec.operators.prometheus.version
+            - fromFieldPath: spec.parameters.services.operators.universal-crossplane.version
+              toFieldPath: spec.operators.universal-crossplane.version
+            - fromFieldPath: spec.id
+              toFieldPath: spec.operators.universal-crossplane.clusterRef

--- a/package/cluster/eks/composition.yaml
+++ b/package/cluster/eks/composition.yaml
@@ -13,7 +13,7 @@ spec:
   pipeline:
   - step: patch-and-transform
     functionRef:
-      name: function-patch-and-transform
+      name: crossplane-contrib-function-patch-and-transform
     input:
       apiVersion: pt.fn.crossplane.io/v1beta1
       kind: Resources

--- a/package/cluster/eks/composition.yaml
+++ b/package/cluster/eks/composition.yaml
@@ -9,291 +9,303 @@ spec:
   compositeTypeRef:
     apiVersion: aws.platformref.upbound.io/v1alpha1
     kind: XEKS
-  resources:
-    - base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Role
-        metadata:
-          labels:
-            role: controlplane
-        spec:
-          forProvider:
-            assumeRolePolicy: |
-              {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {
-                            "Service": [
-                                "eks.amazonaws.com"
-                            ]
-                        },
-                        "Action": [
-                            "sts:AssumeRole"
-                        ]
-                    }
-                ]
-              }
-      name: controlplaneRole
-    - base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          forProvider:
-            policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-            roleSelector:
-              matchControllerRef: true
-              matchLabels:
+  mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+        - base:
+            apiVersion: iam.aws.upbound.io/v1beta1
+            kind: Role
+            metadata:
+              labels:
                 role: controlplane
-      name: clusterRolePolicyAttachment
-    - base:
-        apiVersion: eks.aws.upbound.io/v1beta1
-        kind: Cluster
-        spec:
-          forProvider:
-            region: us-west-2
-            roleArnSelector:
-              matchControllerRef: true
-              matchLabels:
-                role: controlplane
-            vpcConfig:
-              - endpointPrivateAccess: true
-                endpointPublicAccess: true
-      name: kubernetesCluster
-      patches:
-          # Change to spec id
-        - fromFieldPath: spec.parameters.securityGroupIds
-          toFieldPath: spec.forProvider.vpcConfig[0].securityGroupIds
-        - fromFieldPath: spec.parameters.subnetIds
-          toFieldPath: spec.forProvider.vpcConfig[0].subnetIds
-        - fromFieldPath: spec.parameters.version
-          toFieldPath: spec.forProvider.version
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.identity[0].oidc[0].issuer
-          toFieldPath: status.eks.oidc
-          policy:
-            fromFieldPath: Optional
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.identity[0].oidc[0].issuer
-          toFieldPath: status.eks.oidcUri
-          transforms:
-            - type: string
-              string:
-                type: TrimPrefix
-                trim: 'https://'
-          policy:
-            fromFieldPath: Optional
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.roleArn
-          toFieldPath: status.eks.accountId
-          transforms:
-          - type: string
-            string:
-              type: Regexp
-              regexp:
-                match: 'arn:aws:iam::(\d+):.*'
-                group: 1
-          policy:
-            fromFieldPath: Optional
-    - base:
-        apiVersion: eks.aws.upbound.io/v1beta1
-        kind: ClusterAuth
-        spec:
-          forProvider:
-            region: us-west-2
-            clusterNameSelector:
-              matchControllerRef: true
-      name: kubernetesClusterAuth
-      patches:
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.writeConnectionSecretToRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-ekscluster"
-      connectionDetails:
-        - fromConnectionSecretKey: kubeconfig
-    - base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: Role
-        metadata:
-          labels:
-            role: nodegroup
-        spec:
-          forProvider:
-            assumeRolePolicy: |
-              {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {
-                            "Service": [
-                                "ec2.amazonaws.com"
+            spec:
+              forProvider:
+                assumeRolePolicy: |
+                  {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "eks.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
                             ]
-                        },
-                        "Action": [
-                            "sts:AssumeRole"
-                        ]
-                    }
-                ]
-              }
-      name: nodegroupRole
-    - base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          forProvider:
-            policyArn: arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
-            roleSelector:
-              matchControllerRef: true
-              matchLabels:
+                        }
+                    ]
+                  }
+          name: controlplaneRole
+        - base:
+            apiVersion: iam.aws.upbound.io/v1beta1
+            kind: RolePolicyAttachment
+            spec:
+              forProvider:
+                policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+                roleSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    role: controlplane
+          name: clusterRolePolicyAttachment
+        - base:
+            apiVersion: eks.aws.upbound.io/v1beta1
+            kind: Cluster
+            spec:
+              forProvider:
+                region: us-west-2
+                roleArnSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    role: controlplane
+                vpcConfig:
+                  - endpointPrivateAccess: true
+                    endpointPublicAccess: true
+          name: kubernetesCluster
+          patches:
+              # Change to spec id
+            - fromFieldPath: spec.parameters.securityGroupIds
+              toFieldPath: spec.forProvider.vpcConfig[0].securityGroupIds
+            - fromFieldPath: spec.parameters.subnetIds
+              toFieldPath: spec.forProvider.vpcConfig[0].subnetIds
+            - fromFieldPath: spec.parameters.version
+              toFieldPath: spec.forProvider.version
+            - type: ToCompositeFieldPath
+              fromFieldPath: status.atProvider.identity[0].oidc[0].issuer
+              toFieldPath: status.eks.oidc
+              policy:
+                fromFieldPath: Optional
+            - type: ToCompositeFieldPath
+              fromFieldPath: status.atProvider.identity[0].oidc[0].issuer
+              toFieldPath: status.eks.oidcUri
+              transforms:
+                - type: string
+                  string:
+                    type: TrimPrefix
+                    trim: 'https://'
+              policy:
+                fromFieldPath: Optional
+            - type: ToCompositeFieldPath
+              fromFieldPath: status.atProvider.roleArn
+              toFieldPath: status.eks.accountId
+              transforms:
+              - type: string
+                string:
+                  type: Regexp
+                  regexp:
+                    match: 'arn:aws:iam::(\d+):.*'
+                    group: 1
+              policy:
+                fromFieldPath: Optional
+        - base:
+            apiVersion: eks.aws.upbound.io/v1beta1
+            kind: ClusterAuth
+            spec:
+              forProvider:
+                region: us-west-2
+                clusterNameSelector:
+                  matchControllerRef: true
+          name: kubernetesClusterAuth
+          patches:
+            - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+              toFieldPath: spec.writeConnectionSecretToRef.namespace
+            - fromFieldPath: metadata.uid
+              toFieldPath: spec.writeConnectionSecretToRef.name
+              transforms:
+                - type: string
+                  string:
+                    type: Format
+                    fmt: "%s-ekscluster"
+          connectionDetails:
+            - name: kubeconfig
+              type: FromConnectionSecretKey
+              fromConnectionSecretKey: kubeconfig
+        - base:
+            apiVersion: iam.aws.upbound.io/v1beta1
+            kind: Role
+            metadata:
+              labels:
                 role: nodegroup
-      name: workerNodeRolePolicyAttachment
-    - base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          forProvider:
-            policyArn: arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-            roleSelector:
-              matchControllerRef: true
-              matchLabels:
-                role: nodegroup
-      name: cniRolePolicyAttachment
-    - base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          forProvider:
-            policyArn: arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
-            roleSelector:
-              matchControllerRef: true
-              matchLabels:
-                role: nodegroup
-      name: ebsCsiRolePolicyAttachment
-    - base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: RolePolicyAttachment
-        spec:
-          forProvider:
-            policyArn: arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
-            roleSelector:
-              matchControllerRef: true
-              matchLabels:
-                role: nodegroup
-      name: containerRegistryRolePolicyAttachment
-    - base:
-        apiVersion: eks.aws.upbound.io/v1beta1
-        kind: NodeGroup
-        spec:
-          forProvider:
-            region: us-west-2
-            clusterNameSelector:
-              matchControllerRef: true
-            nodeRoleArnSelector:
-              matchControllerRef: true
-              matchLabels:
-                role: nodegroup
-            subnetIdSelector:
-              matchLabels:
-                access: public
-            scalingConfig:
-              - minSize: 1
-                maxSize: 100
-                desiredSize: 1
-            instanceTypes:
-              - t3.medium
-      name: nodeGroupPublic
-      patches:
-        - fromFieldPath: spec.parameters.nodes.count
-          toFieldPath: spec.forProvider.scalingConfig[0].desiredSize
-        - fromFieldPath: spec.parameters.nodes.size
-          toFieldPath: spec.forProvider.instanceTypes[0]
-          transforms:
-            - type: map
-              map:
-                small: t3.small
-                medium: t3.medium
-                large: t3.large
-        - fromFieldPath: spec.id
-          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.upbound.io/network-id]
-    - base:
-        apiVersion: eks.aws.upbound.io/v1beta1
-        kind: Addon
-        metadata:
-          annotations:
-            crossplane.io/external-name: aws-ebs-csi-driver
-        spec:
-          forProvider:
-            addonName: aws-ebs-csi-driver
-            clusterNameSelector:
-              matchControllerRef: true
-            region: us-west-2
-      name: ebsCsiAddon
-    - base:
-        apiVersion: iam.aws.upbound.io/v1beta1
-        kind: OpenIDConnectProvider
-        spec:
-          forProvider:
-            clientIdList:
-              - sts.amazonaws.com
-            thumbprintList:
-              - "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
-      name: oidcProvider
-      patches:
-        - fromFieldPath: status.eks.oidc
-          toFieldPath: spec.forProvider.url
-          policy:
-            fromFieldPath: Required
-    - base:
-        apiVersion: helm.crossplane.io/v1beta1
-        kind: ProviderConfig
-        spec:
-          credentials:
-            source: Secret
-            secretRef:
-              key: kubeconfig
-      name: providerConfig
-      patches:
-        - fromFieldPath: spec.id
-          toFieldPath: metadata.name
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.credentials.secretRef.namespace
-        # This ProviderConfig uses the above EKS cluster's connection secret as
-        # its credentials secret.
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.credentials.secretRef.name
-          transforms:
-            - type: string
+            spec:
+              forProvider:
+                assumeRolePolicy: |
+                  {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                  }
+          name: nodegroupRole
+        - base:
+            apiVersion: iam.aws.upbound.io/v1beta1
+            kind: RolePolicyAttachment
+            spec:
+              forProvider:
+                policyArn: arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+                roleSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    role: nodegroup
+          name: workerNodeRolePolicyAttachment
+        - base:
+            apiVersion: iam.aws.upbound.io/v1beta1
+            kind: RolePolicyAttachment
+            spec:
+              forProvider:
+                policyArn: arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+                roleSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    role: nodegroup
+          name: cniRolePolicyAttachment
+        - base:
+            apiVersion: iam.aws.upbound.io/v1beta1
+            kind: RolePolicyAttachment
+            spec:
+              forProvider:
+                policyArn: arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+                roleSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    role: nodegroup
+          name: ebsCsiRolePolicyAttachment
+        - base:
+            apiVersion: iam.aws.upbound.io/v1beta1
+            kind: RolePolicyAttachment
+            spec:
+              forProvider:
+                policyArn: arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+                roleSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    role: nodegroup
+          name: containerRegistryRolePolicyAttachment
+        - base:
+            apiVersion: eks.aws.upbound.io/v1beta1
+            kind: NodeGroup
+            spec:
+              forProvider:
+                region: us-west-2
+                clusterNameSelector:
+                  matchControllerRef: true
+                nodeRoleArnSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    role: nodegroup
+                subnetIdSelector:
+                  matchLabels:
+                    access: public
+                scalingConfig:
+                  - minSize: 1
+                    maxSize: 100
+                    desiredSize: 1
+                instanceTypes:
+                  - t3.medium
+          name: nodeGroupPublic
+          patches:
+            - fromFieldPath: spec.parameters.nodes.count
+              toFieldPath: spec.forProvider.scalingConfig[0].desiredSize
+            - fromFieldPath: spec.parameters.nodes.size
+              toFieldPath: spec.forProvider.instanceTypes[0]
+              transforms:
+                - type: map
+                  map:
+                    small: t3.small
+                    medium: t3.medium
+                    large: t3.large
+            - fromFieldPath: spec.id
+              toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.upbound.io/network-id]
+        - base:
+            apiVersion: eks.aws.upbound.io/v1beta1
+            kind: Addon
+            metadata:
+              annotations:
+                crossplane.io/external-name: aws-ebs-csi-driver
+            spec:
+              forProvider:
+                addonName: aws-ebs-csi-driver
+                clusterNameSelector:
+                  matchControllerRef: true
+                region: us-west-2
+          name: ebsCsiAddon
+        - base:
+            apiVersion: iam.aws.upbound.io/v1beta1
+            kind: OpenIDConnectProvider
+            spec:
+              forProvider:
+                clientIdList:
+                  - sts.amazonaws.com
+                thumbprintList:
+                  - "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
+          name: oidcProvider
+          patches:
+            - fromFieldPath: status.eks.oidc
+              toFieldPath: spec.forProvider.url
+              policy:
+                fromFieldPath: Required
+        - base:
+            apiVersion: helm.crossplane.io/v1beta1
+            kind: ProviderConfig
+            spec:
+              credentials:
+                source: Secret
+                secretRef:
+                  key: kubeconfig
+          name: providerConfig
+          patches:
+            - fromFieldPath: spec.id
+              toFieldPath: metadata.name
+            - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+              toFieldPath: spec.credentials.secretRef.namespace
+            # This ProviderConfig uses the above EKS cluster's connection secret as
+            # its credentials secret.
+            - fromFieldPath: metadata.uid
+              toFieldPath: spec.credentials.secretRef.name
+              transforms:
+                - type: string
+                  string:
+                    type: Format
+                    fmt: "%s-ekscluster"
+          readinessChecks:
+            - type: None
+        - base:
+            apiVersion: apiextensions.crossplane.io/v1alpha1
+            kind: EnvironmentConfig
+          name: irsa-environmentconfig
+          patches:
+          - fromFieldPath: spec.id
+            toFieldPath: metadata.labels[clusterRef]
+          - fromFieldPath: status.eks.oidcUri
+            toFieldPath: data.oidcHost
+          - fromFieldPath: status.eks.accountId
+            toFieldPath: data.accountId
+          - type: CombineFromComposite
+            toFieldPath: data.oidcArn
+            policy:
+              fromFieldPath: Required
+            combine:
+              variables:
+                - fromFieldPath: status.eks.accountId
+                - fromFieldPath: status.eks.oidcUri
+              strategy: string
               string:
-                fmt: "%s-ekscluster"
-      readinessChecks:
-        - type: None
-    - base:
-        apiVersion: apiextensions.crossplane.io/v1alpha1
-        kind: EnvironmentConfig
-      name: irsa-environmentconfig
-      patches:
-      - fromFieldPath: spec.id
-        toFieldPath: metadata.labels[clusterRef]
-      - fromFieldPath: status.eks.oidcUri
-        toFieldPath: data.oidcHost
-      - fromFieldPath: status.eks.accountId
-        toFieldPath: data.accountId
-      - type: CombineFromComposite
-        toFieldPath: data.oidcArn
-        policy:
-          fromFieldPath: Required
-        combine:
-          variables:
-            - fromFieldPath: status.eks.accountId
-            - fromFieldPath: status.eks.oidcUri
-          strategy: string
-          string:
-            fmt: 'arn:aws:iam::%s:oidc-provider/%s'
-      readinessChecks:
-        - type: None
+                fmt: 'arn:aws:iam::%s:oidc-provider/%s'
+          readinessChecks:
+            - type: None

--- a/package/cluster/irsa/composition.yaml
+++ b/package/cluster/irsa/composition.yaml
@@ -42,6 +42,8 @@ spec:
       metadata:
         labels:
           resource: "Role"
+      spec:
+        forProvider: {}
     patches:
     - type: PatchSet
       patchSetName: Name

--- a/package/cluster/network/composition.yaml
+++ b/package/cluster/network/composition.yaml
@@ -13,7 +13,7 @@ spec:
   pipeline:
   - step: patch-and-transform
     functionRef:
-      name: function-patch-and-transform
+      name: crossplane-contrib-function-patch-and-transform
     input:
       apiVersion: pt.fn.crossplane.io/v1beta1
       kind: Resources

--- a/package/cluster/network/composition.yaml
+++ b/package/cluster/network/composition.yaml
@@ -9,296 +9,304 @@ spec:
   compositeTypeRef:
     apiVersion: aws.platformref.upbound.io/v1alpha1
     kind: XNetwork
-  patchSets:
-  - name: network-id
-    patches:
-    - type: FromCompositeFieldPath
-      fromFieldPath: spec.id
-      toFieldPath: metadata.labels[networks.aws.platformref.upbound.io/network-id]
-  resources:
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: VPC
-        spec:
-          forProvider:
-            region: us-west-2
-            cidrBlock: 192.168.0.0/16
-            enableDnsSupport: true
-            enableDnsHostnames: true
-            tags:
-              Owner: Platform Team
-              Name: platformref-vpc
-      name: platformref-vcp
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: InternetGateway
-        spec:
-          forProvider:
-            region: us-west-2
-            vpcIdSelector:
-              matchControllerRef: true
-      name: gateway
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: Subnet
-        metadata:
-          labels:
-            zone: us-west-2a
-            access: public
-        spec:
-          forProvider:
-            region: us-west-2
-            mapPublicIpOnLaunch: true
-            cidrBlock: 192.168.0.0/18
-            vpcIdSelector:
-              matchControllerRef: true
-            availabilityZone: us-west-2a
-            tags:
-              kubernetes.io/role/elb: "1"
-      name: subnet-public-west-2a
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-        - type: ToCompositeFieldPath
-          fromFieldPath: metadata.annotations[crossplane.io/external-name]
-          toFieldPath: status.subnetIds[0]
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: Subnet
-        metadata:
-          labels:
-            zone: us-west-2b
-            access: public
-        spec:
-          forProvider:
-            region: us-west-2
-            mapPublicIpOnLaunch: true
-            cidrBlock: 192.168.64.0/18
-            vpcIdSelector:
-              matchControllerRef: true
-            availabilityZone: us-west-2b
-            tags:
-              kubernetes.io/role/elb: "1"
-      name: subnet-public-west-2b
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-        - type: ToCompositeFieldPath
-          fromFieldPath: metadata.annotations[crossplane.io/external-name]
-          toFieldPath: status.subnetIds[1]
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: Subnet
-        metadata:
-          labels:
-            zone: us-west-2a
-            access: private
-        spec:
-          forProvider:
-            region: us-west-2
-            cidrBlock: 192.168.128.0/18
-            vpcIdSelector:
-              matchControllerRef: true
-            availabilityZone: us-west-2a
-            tags:
-              kubernetes.io/role/internal-elb: "1"
-      name: subnet-private-west-2a
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-        - type: ToCompositeFieldPath
-          fromFieldPath: metadata.annotations[crossplane.io/external-name]
-          toFieldPath: status.subnetIds[2]
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: Subnet
-        metadata:
-          labels:
-            zone: us-west-2b
-            access: private
-        spec:
-          forProvider:
-            region: us-west-2
-            cidrBlock: 192.168.192.0/18
-            vpcIdSelector:
-              matchControllerRef: true
-            availabilityZone: us-west-2b
-            tags:
-              kubernetes.io/role/internal-elb: "1"
-      name: subnet-private-west-2b
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-        - type: ToCompositeFieldPath
-          fromFieldPath: metadata.annotations[crossplane.io/external-name]
-          toFieldPath: status.subnetIds[3]
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: RouteTable
-        spec:
-          forProvider:
-            region: us-west-2
-            vpcIdSelector:
-              matchControllerRef: true
-      name: routeTable
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: Route
-        spec:
-          forProvider:
-            region: us-west-2
-            destinationCidrBlock: 0.0.0.0/0
-            gatewayIdSelector:
-              matchControllerRef: true
-            routeTableIdSelector:
-              matchControllerRef: true
-      name: route
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: MainRouteTableAssociation
-        spec:
-          forProvider:
-            region: us-west-2
-            routeTableIdSelector:
-              matchControllerRef: true
-            vpcIdSelector:
-              matchControllerRef: true
-      name: mainRouteTableAssociation
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: RouteTableAssociation
-        spec:
-          forProvider:
-            region: us-west-2
-            routeTableIdSelector:
-              matchControllerRef: true
-            subnetIdSelector:
-              matchControllerRef: true
-              matchLabels:
+  mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      patchSets:
+      - name: network-id
+        patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.id
+          toFieldPath: metadata.labels[networks.aws.platformref.upbound.io/network-id]
+      resources:
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: VPC
+            spec:
+              forProvider:
+                region: us-west-2
+                cidrBlock: 192.168.0.0/16
+                enableDnsSupport: true
+                enableDnsHostnames: true
+                tags:
+                  Owner: Platform Team
+                  Name: platformref-vpc
+          name: platformref-vcp
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: InternetGateway
+            spec:
+              forProvider:
+                region: us-west-2
+                vpcIdSelector:
+                  matchControllerRef: true
+          name: gateway
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: Subnet
+            metadata:
+              labels:
                 zone: us-west-2a
                 access: public
-      name: RouteTableAssociation-public-a
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: RouteTableAssociation
-        spec:
-          forProvider:
-            region: us-west-2
-            routeTableIdSelector:
-              matchControllerRef: true
-            subnetIdSelector:
-              matchControllerRef: true
-              matchLabels:
+            spec:
+              forProvider:
+                region: us-west-2
+                mapPublicIpOnLaunch: true
+                cidrBlock: 192.168.0.0/18
+                vpcIdSelector:
+                  matchControllerRef: true
+                availabilityZone: us-west-2a
+                tags:
+                  kubernetes.io/role/elb: "1"
+          name: subnet-public-west-2a
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+            - type: ToCompositeFieldPath
+              fromFieldPath: metadata.annotations[crossplane.io/external-name]
+              toFieldPath: status.subnetIds[0]
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: Subnet
+            metadata:
+              labels:
                 zone: us-west-2b
                 access: public
-      name: RouteTableAssociation-public-b
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: RouteTableAssociation
-        spec:
-          forProvider:
-            region: us-west-2
-            routeTableIdSelector:
-              matchControllerRef: true
-            subnetIdSelector:
-              matchControllerRef: true
-              matchLabels:
+            spec:
+              forProvider:
+                region: us-west-2
+                mapPublicIpOnLaunch: true
+                cidrBlock: 192.168.64.0/18
+                vpcIdSelector:
+                  matchControllerRef: true
+                availabilityZone: us-west-2b
+                tags:
+                  kubernetes.io/role/elb: "1"
+          name: subnet-public-west-2b
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+            - type: ToCompositeFieldPath
+              fromFieldPath: metadata.annotations[crossplane.io/external-name]
+              toFieldPath: status.subnetIds[1]
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: Subnet
+            metadata:
+              labels:
                 zone: us-west-2a
                 access: private
-      name: RouteTableAssociation-private-a
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-    - base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: RouteTableAssociation
-        spec:
-          forProvider:
-            region: us-west-2
-            routeTableIdSelector:
-              matchControllerRef: true
-            subnetIdSelector:
-              matchControllerRef: true
-              matchLabels:
+            spec:
+              forProvider:
+                region: us-west-2
+                cidrBlock: 192.168.128.0/18
+                vpcIdSelector:
+                  matchControllerRef: true
+                availabilityZone: us-west-2a
+                tags:
+                  kubernetes.io/role/internal-elb: "1"
+          name: subnet-private-west-2a
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+            - type: ToCompositeFieldPath
+              fromFieldPath: metadata.annotations[crossplane.io/external-name]
+              toFieldPath: status.subnetIds[2]
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: Subnet
+            metadata:
+              labels:
                 zone: us-west-2b
                 access: private
-      name: RouteTableAssociation-private-b
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-    - name: securityGroup
-      base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: SecurityGroup
-        spec:
-          forProvider:
-            region: us-west-2
-            vpcIdSelector:
-              matchControllerRef: true
-            name: platform-ref-aws-cluster
-            description: Allow access to databases
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-        - type: ToCompositeFieldPath
-          fromFieldPath: metadata.annotations[crossplane.io/external-name]
-          toFieldPath: status.securityGroupIds[0]
-    - name: securityGroupRulePostgres
-      base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: SecurityGroupRule
-        spec:
-          forProvider:
-            region: us-west-2
-            type: ingress
-            fromPort: 5432
-            toPort: 5432
-            protocol: tcp
-            cidrBlocks:
-              - 0.0.0.0/0
-            securityGroupIdSelector:
-              matchControllerRef: true
-            description: Everywhere
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
-    - name: securityGroupRuleMysql
-      base:
-        apiVersion: ec2.aws.upbound.io/v1beta1
-        kind: SecurityGroupRule
-        spec:
-          forProvider:
-            region: us-west-2
-            type: ingress
-            fromPort: 3306
-            toPort: 3306
-            protocol: tcp
-            cidrBlocks:
-              - 0.0.0.0/0
-            securityGroupIdSelector:
-              matchControllerRef: true
-            description: Everywhere
-      patches:
-        - type: PatchSet
-          patchSetName: network-id
+            spec:
+              forProvider:
+                region: us-west-2
+                cidrBlock: 192.168.192.0/18
+                vpcIdSelector:
+                  matchControllerRef: true
+                availabilityZone: us-west-2b
+                tags:
+                  kubernetes.io/role/internal-elb: "1"
+          name: subnet-private-west-2b
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+            - type: ToCompositeFieldPath
+              fromFieldPath: metadata.annotations[crossplane.io/external-name]
+              toFieldPath: status.subnetIds[3]
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: RouteTable
+            spec:
+              forProvider:
+                region: us-west-2
+                vpcIdSelector:
+                  matchControllerRef: true
+          name: routeTable
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: Route
+            spec:
+              forProvider:
+                region: us-west-2
+                destinationCidrBlock: 0.0.0.0/0
+                gatewayIdSelector:
+                  matchControllerRef: true
+                routeTableIdSelector:
+                  matchControllerRef: true
+          name: route
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: MainRouteTableAssociation
+            spec:
+              forProvider:
+                region: us-west-2
+                routeTableIdSelector:
+                  matchControllerRef: true
+                vpcIdSelector:
+                  matchControllerRef: true
+          name: mainRouteTableAssociation
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: RouteTableAssociation
+            spec:
+              forProvider:
+                region: us-west-2
+                routeTableIdSelector:
+                  matchControllerRef: true
+                subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    zone: us-west-2a
+                    access: public
+          name: RouteTableAssociation-public-a
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: RouteTableAssociation
+            spec:
+              forProvider:
+                region: us-west-2
+                routeTableIdSelector:
+                  matchControllerRef: true
+                subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    zone: us-west-2b
+                    access: public
+          name: RouteTableAssociation-public-b
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: RouteTableAssociation
+            spec:
+              forProvider:
+                region: us-west-2
+                routeTableIdSelector:
+                  matchControllerRef: true
+                subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    zone: us-west-2a
+                    access: private
+          name: RouteTableAssociation-private-a
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+        - base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: RouteTableAssociation
+            spec:
+              forProvider:
+                region: us-west-2
+                routeTableIdSelector:
+                  matchControllerRef: true
+                subnetIdSelector:
+                  matchControllerRef: true
+                  matchLabels:
+                    zone: us-west-2b
+                    access: private
+          name: RouteTableAssociation-private-b
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+        - name: securityGroup
+          base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: SecurityGroup
+            spec:
+              forProvider:
+                region: us-west-2
+                vpcIdSelector:
+                  matchControllerRef: true
+                name: platform-ref-aws-cluster
+                description: Allow access to databases
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+            - type: ToCompositeFieldPath
+              fromFieldPath: metadata.annotations[crossplane.io/external-name]
+              toFieldPath: status.securityGroupIds[0]
+        - name: securityGroupRulePostgres
+          base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: SecurityGroupRule
+            spec:
+              forProvider:
+                region: us-west-2
+                type: ingress
+                fromPort: 5432
+                toPort: 5432
+                protocol: tcp
+                cidrBlocks:
+                  - 0.0.0.0/0
+                securityGroupIdSelector:
+                  matchControllerRef: true
+                description: Everywhere
+          patches:
+            - type: PatchSet
+              patchSetName: network-id
+        - name: securityGroupRuleMysql
+          base:
+            apiVersion: ec2.aws.upbound.io/v1beta1
+            kind: SecurityGroupRule
+            spec:
+              forProvider:
+                region: us-west-2
+                type: ingress
+                fromPort: 3306
+                toPort: 3306
+                protocol: tcp
+                cidrBlocks:
+                  - 0.0.0.0/0
+                securityGroupIdSelector:
+                  matchControllerRef: true
+                description: Everywhere
+          patches:
+            - type: PatchSet
+              patchSetName: network-id

--- a/package/cluster/services/composition.yaml
+++ b/package/cluster/services/composition.yaml
@@ -14,7 +14,7 @@ spec:
   pipeline:
   - step: patch-and-transform
     functionRef:
-      name: function-patch-and-transform
+      name: crossplane-contrib-function-patch-and-transform
     input:
       apiVersion: pt.fn.crossplane.io/v1beta1
       kind: Resources

--- a/package/cluster/services/composition.yaml
+++ b/package/cluster/services/composition.yaml
@@ -10,113 +10,121 @@ spec:
   compositeTypeRef:
     apiVersion: aws.platformref.upbound.io/v1alpha1
     kind: XServices
-  resources:
-    - name: releasePrometheus
-      base:
-        apiVersion: helm.crossplane.io/v1beta1
-        kind: Release
-        spec:
-          rollbackLimit: 3
-          forProvider:
-            namespace: operators
-            chart:
-              # from https://github.com/prometheus-community/helm-charts
-              # Note that default values are overridden by the patches below.
-              name: kube-prometheus-stack
-              repository: https://prometheus-community.github.io/helm-charts
-              version: "41.4.1"
-            values: {}
-      patches:
-        # All Helm releases derive their labels and annotations from the XR.
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        # All Helm releases derive the ProviderConfig to use from the XR.
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        # Derive the Prometheus operator image and tag from the XR.
-        - fromFieldPath: spec.operators.prometheus.version
-          toFieldPath: spec.forProvider.chart.version
+  mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+        - name: releasePrometheus
+          base:
+            apiVersion: helm.crossplane.io/v1beta1
+            kind: Release
+            spec:
+              rollbackLimit: 3
+              forProvider:
+                namespace: operators
+                chart:
+                  # from https://github.com/prometheus-community/helm-charts
+                  # Note that default values are overridden by the patches below.
+                  name: kube-prometheus-stack
+                  repository: https://prometheus-community.github.io/helm-charts
+                  version: "41.4.1"
+                values: {}
+          patches:
+            # All Helm releases derive their labels and annotations from the XR.
+            - fromFieldPath: metadata.labels
+              toFieldPath: metadata.labels
+            - fromFieldPath: metadata.annotations
+              toFieldPath: metadata.annotations
+            # All Helm releases derive the ProviderConfig to use from the XR.
+            - fromFieldPath: spec.providerConfigRef.name
+              toFieldPath: spec.providerConfigRef.name
+            # Derive the Prometheus operator image and tag from the XR.
+            - fromFieldPath: spec.operators.prometheus.version
+              toFieldPath: spec.forProvider.chart.version
 
-    - name: irsaCrossplane
-      base:
-        apiVersion: aws.platformref.upbound.io/v1alpha1
-        kind: XIRSA
-        spec:
-          parameters:
-            condition: StringEquals
-            policyDocument: |
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Action": [
-                                "ecr:ListTagsForResource",
-                                "ecr:ListImages",
-                                "ecr:GetRepositoryPolicy",
-                                "ecr:GetLifecyclePolicyPreview",
-                                "ecr:GetLifecyclePolicy",
-                                "ecr:GetDownloadUrlForLayer",
-                                "ecr:GetAuthorizationToken",
-                                "ecr:DescribeRepositories",
-                                "ecr:DescribeImages",
-                                "ecr:DescribeImageScanFindings",
-                                "ecr:BatchGetImage",
-                                "ecr:BatchCheckLayerAvailability"
-                            ],
-                            "Effect": "Allow",
-                            "Resource": "*"
-                        }
-                    ]
-                }
-            serviceAccount:
-              name: crossplane
-              namespace: upbound-system
-      patches:
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: metadata.name
-          transforms:
-            - type: match
-              match:
-                patterns:
-                  - type: regexp
-                    regexp: '.*'
-                    result: irsa-crossplane
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.roleArn
-          toFieldPath: status.roleArn
-          policy:
-            fromFieldPath: Optional
-        - fromFieldPath: spec.operators.universal-crossplane.clusterRef
-          toFieldPath: spec.parameters.clusterRef.id
+        - name: irsaCrossplane
+          base:
+            apiVersion: aws.platformref.upbound.io/v1alpha1
+            kind: XIRSA
+            spec:
+              parameters:
+                condition: StringEquals
+                policyDocument: |
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Action": [
+                                    "ecr:ListTagsForResource",
+                                    "ecr:ListImages",
+                                    "ecr:GetRepositoryPolicy",
+                                    "ecr:GetLifecyclePolicyPreview",
+                                    "ecr:GetLifecyclePolicy",
+                                    "ecr:GetDownloadUrlForLayer",
+                                    "ecr:GetAuthorizationToken",
+                                    "ecr:DescribeRepositories",
+                                    "ecr:DescribeImages",
+                                    "ecr:DescribeImageScanFindings",
+                                    "ecr:BatchGetImage",
+                                    "ecr:BatchCheckLayerAvailability"
+                                ],
+                                "Effect": "Allow",
+                                "Resource": "*"
+                            }
+                        ]
+                    }
+                serviceAccount:
+                  name: crossplane
+                  namespace: upbound-system
+          patches:
+            - fromFieldPath: spec.providerConfigRef.name
+              toFieldPath: metadata.name
+              transforms:
+                - type: match
+                  match:
+                    patterns:
+                      - type: regexp
+                        regexp: '.*'
+                        result: irsa-crossplane
+            - type: ToCompositeFieldPath
+              fromFieldPath: status.roleArn
+              toFieldPath: status.roleArn
+              policy:
+                fromFieldPath: Optional
+            - fromFieldPath: spec.operators.universal-crossplane.clusterRef
+              toFieldPath: spec.parameters.clusterRef.id
 
-    - name: releaseUXP
-      base:
-        apiVersion: helm.crossplane.io/v1beta1
-        kind: Release
-        spec:
-          rollbackLimit: 3
-          forProvider:
-            namespace: upbound-system
-            chart:
-              # from https://github.com/upbound/universal-crossplane
-              # Note that default values are overridden by the patches below.
-              name: universal-crossplane
-              repository: https://charts.upbound.io/stable
-            values: {}
-      patches:
-        # All Helm releases derive their labels and annotations from the XR.
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        # All Helm releases derive the ProviderConfig to use from the XR.
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.operators.universal-crossplane.version
-          toFieldPath: spec.forProvider.chart.version
-        - fromFieldPath: status.roleArn
-          toFieldPath: spec.forProvider.values.serviceAccount.customAnnotations[eks.amazonaws.com/role-arn]
-          policy:
-            fromFieldPath: Required
+        - name: releaseUXP
+          base:
+            apiVersion: helm.crossplane.io/v1beta1
+            kind: Release
+            spec:
+              rollbackLimit: 3
+              forProvider:
+                namespace: upbound-system
+                chart:
+                  # from https://github.com/upbound/universal-crossplane
+                  # Note that default values are overridden by the patches below.
+                  name: universal-crossplane
+                  repository: https://charts.upbound.io/stable
+                values: {}
+          patches:
+            # All Helm releases derive their labels and annotations from the XR.
+            - fromFieldPath: metadata.labels
+              toFieldPath: metadata.labels
+            - fromFieldPath: metadata.annotations
+              toFieldPath: metadata.annotations
+            # All Helm releases derive the ProviderConfig to use from the XR.
+            - fromFieldPath: spec.providerConfigRef.name
+              toFieldPath: spec.providerConfigRef.name
+            - fromFieldPath: spec.operators.universal-crossplane.version
+              toFieldPath: spec.forProvider.chart.version
+            - fromFieldPath: status.roleArn
+              toFieldPath: spec.forProvider.values.serviceAccount.customAnnotations[eks.amazonaws.com/role-arn]
+              policy:
+                fromFieldPath: Required

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -28,15 +28,17 @@ metadata:
       customize to meet the exact needs of your organization!
 spec:
   crossplane:
-    version: ">=v1.12.1-0"
+    version: ">=v1.14.0-0"
   dependsOn:
     - provider: xpkg.upbound.io/crossplane-contrib/provider-helm
       version: ">=v0.15.0"
     - provider: xpkg.upbound.io/upbound/provider-aws-ec2
-      version: ">=v0.36.0"
+      version: ">=v0.41.0"
     - provider: xpkg.upbound.io/upbound/provider-aws-eks
-      version: ">=v0.36.0"
+      version: ">=v0.41.0"
     - provider: xpkg.upbound.io/upbound/provider-aws-iam
-      version: ">=v0.36.0"
+      version: ">=v0.41.0"
     - provider: xpkg.upbound.io/upbound/provider-aws-rds
-      version: ">=v0.36.0"
+      version: ">=v0.41.0"
+    - function: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
+      version: ">-v0.1.4"

--- a/package/database/sqlinstance/composition.yaml
+++ b/package/database/sqlinstance/composition.yaml
@@ -13,7 +13,7 @@ spec:
   pipeline:
   - step: patch-and-transform
     functionRef:
-      name: function-patch-and-transform
+      name: crossplane-contrib-function-patch-and-transform
     input:
       apiVersion: pt.fn.crossplane.io/v1beta1
       kind: Resources

--- a/package/database/sqlinstance/composition.yaml
+++ b/package/database/sqlinstance/composition.yaml
@@ -9,65 +9,79 @@ spec:
   compositeTypeRef:
     apiVersion: aws.platformref.upbound.io/v1alpha1
     kind: XSQLInstance
-  resources:
-    - name: compositeSQLInstanceDbSubnetGroup
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: SubnetGroup
-        spec:
-          forProvider:
-            region: us-west-2
-            description: An excellent formation of subnetworks.
-          deletionPolicy: Delete
-      patches:
-        - fromFieldPath: spec.parameters.clusterRef.id
-          toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.upbound.io/network-id]
-    - name: RDSInstanceSmall
-      base:
-        apiVersion: rds.aws.upbound.io/v1beta1
-        kind: Instance
-        spec:
-          forProvider:
-            region: us-west-2
-            dbSubnetGroupNameSelector:
-              matchControllerRef: true
-            instanceClass: db.t3.micro
-            username: masteruser
-            skipFinalSnapshot: true
-            publiclyAccessible: false
-            dbName: upbound # create custom database within the instance by default
-          deletionPolicy: Delete
-      patches:
-        - fromFieldPath: "metadata.uid"
-          toFieldPath: "spec.writeConnectionSecretToRef.name"
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-sql" #change
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: spec.parameters.engine
-          toFieldPath: spec.forProvider.engine
-        - fromFieldPath: spec.parameters.engineVersion
-          toFieldPath: spec.forProvider.engineVersion
-        - fromFieldPath: spec.parameters.storageGB
-          toFieldPath: spec.forProvider.allocatedStorage
-        - fromFieldPath: spec.parameters.clusterRef.id
-          toFieldPath: spec.forProvider.vpcSecurityGroupIdSelector.matchLabels[networks.aws.platformref.upbound.io/network-id]
-        - fromFieldPath: spec.parameters.autoGeneratePassword
-          toFieldPath: spec.forProvider.autoGeneratePassword
-        - fromFieldPath: spec.parameters.passwordSecretRef.namespace
-          toFieldPath: spec.forProvider.passwordSecretRef.namespace
-        - fromFieldPath: spec.parameters.passwordSecretRef.name
-          toFieldPath: spec.forProvider.passwordSecretRef.name
-        - fromFieldPath: spec.parameters.passwordSecretRef.key
-          toFieldPath: spec.forProvider.passwordSecretRef.key
-      connectionDetails:
-        - fromFieldPath: "status.atProvider.endpoint"
-          name: endpoint
-        - fromFieldPath: "status.atProvider.address"
-          name: host
-        - fromFieldPath: "spec.forProvider.username"
-          name: username
-        - fromConnectionSecretKey: "attribute.password"
-          name: password
+  mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+        - name: compositeSQLInstanceDbSubnetGroup
+          base:
+            apiVersion: rds.aws.upbound.io/v1beta1
+            kind: SubnetGroup
+            spec:
+              forProvider:
+                region: us-west-2
+                description: An excellent formation of subnetworks.
+              deletionPolicy: Delete
+          patches:
+            - fromFieldPath: spec.parameters.clusterRef.id
+              toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platformref.upbound.io/network-id]
+        - name: RDSInstanceSmall
+          base:
+            apiVersion: rds.aws.upbound.io/v1beta1
+            kind: Instance
+            spec:
+              forProvider:
+                region: us-west-2
+                dbSubnetGroupNameSelector:
+                  matchControllerRef: true
+                instanceClass: db.t3.micro
+                username: masteruser
+                skipFinalSnapshot: true
+                publiclyAccessible: false
+                dbName: upbound # create custom database within the instance by default
+              deletionPolicy: Delete
+          patches:
+            - fromFieldPath: "metadata.uid"
+              toFieldPath: "spec.writeConnectionSecretToRef.name"
+              transforms:
+              - type: string
+                string:
+                  type: Format
+                  fmt: "%s-sql"
+            - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+              toFieldPath: spec.writeConnectionSecretToRef.namespace
+            - fromFieldPath: spec.parameters.engine
+              toFieldPath: spec.forProvider.engine
+            - fromFieldPath: spec.parameters.engineVersion
+              toFieldPath: spec.forProvider.engineVersion
+            - fromFieldPath: spec.parameters.storageGB
+              toFieldPath: spec.forProvider.allocatedStorage
+            - fromFieldPath: spec.parameters.clusterRef.id
+              toFieldPath: spec.forProvider.vpcSecurityGroupIdSelector.matchLabels[networks.aws.platformref.upbound.io/network-id]
+            - fromFieldPath: spec.parameters.autoGeneratePassword
+              toFieldPath: spec.forProvider.autoGeneratePassword
+            - fromFieldPath: spec.parameters.passwordSecretRef.namespace
+              toFieldPath: spec.forProvider.passwordSecretRef.namespace
+            - fromFieldPath: spec.parameters.passwordSecretRef.name
+              toFieldPath: spec.forProvider.passwordSecretRef.name
+            - fromFieldPath: spec.parameters.passwordSecretRef.key
+              toFieldPath: spec.forProvider.passwordSecretRef.key
+          connectionDetails:
+            - type: FromFieldPath
+              fromFieldPath: "status.atProvider.endpoint"
+              name: endpoint
+            - type: FromFieldPath
+              fromFieldPath: "status.atProvider.address"
+              name: host
+            - type: FromFieldPath
+              fromFieldPath: "spec.forProvider.username"
+              name: username
+            - type: FromConnectionSecretKey
+              fromConnectionSecretKey: "attribute.password"
+              name: password
+           


### PR DESCRIPTION
### Description of your changes

Migrate compositions to use https://github.com/crossplane-contrib/function-patch-and-transform coming 1.14

XCluster and XIRSA have not been updated due to nested compositions and EnvConfig Support

Requires minimum of [xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4](http://xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4)

```
kubectl get claim, composite
NAME                                                          SYNCED   READY   CONNECTION-SECRET                   AGE
app.aws.platformref.upbound.io/borrelli-function-test-ghost   True     True    borrelli-function-test-ghost-conn   7m17s

NAME                                                                 SYNCED   READY   CONNECTION-SECRET                     AGE
sqlinstance.aws.platformref.upbound.io/platform-ref-aws-db-mariadb   True     True    borrelli-function-test-conn-mariadb   29m

NAME                                                        SYNCED   READY   CONNECTION-SECRET             AGE
cluster.aws.platformref.upbound.io/borrelli-function-test   True     True    platform-ref-aws-kubeconfig   100m

NAME                                               SYNCED   READY   COMPOSITION                         AGE
xirsa.aws.platformref.upbound.io/irsa-crossplane   True     True    xirsas.aws.platformref.upbound.io   100m

NAME                                                                 SYNCED   READY   COMPOSITION                        AGE
xapp.aws.platformref.upbound.io/borrelli-function-test-ghost-dt9nr   True     True    xapps.aws.platformref.upbound.io   7m17s

NAME                                                                        SYNCED   READY   COMPOSITION                                AGE
xsqlinstance.aws.platformref.upbound.io/platform-ref-aws-db-mariadb-8pxzq   True     True    xsqlinstances.aws.platformref.upbound.io   29m

NAME                                                               SYNCED   READY   COMPOSITION                            AGE
xcluster.aws.platformref.upbound.io/borrelli-function-test-9pq6z   True     True    xclusters.aws.platformref.upbound.io   100m

NAME                                                                 SYNCED   READY   COMPOSITION                       AGE
xeks.aws.platformref.upbound.io/borrelli-function-test-9pq6z-62qdh   True     True    xeks.aws.platformref.upbound.io   94m

NAME                                                                     SYNCED   READY   COMPOSITION                            AGE
xnetwork.aws.platformref.upbound.io/borrelli-function-test-9pq6z-nsvpp   True     True    xnetworks.aws.platformref.upbound.io   100m

NAME                                                                      SYNCED   READY   COMPOSITION                            AGE
xservices.aws.platformref.upbound.io/borrelli-function-test-9pq6z-kzchm   True     True    xservices.aws.platformref.upbound.io   100m
```

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
