### PR TITLE
Move function-p&t from upbound to crossplane-contrib

### DIFF
--- a/apis/cluster/composition.yaml
+++ b/apis/cluster/composition.yaml
@@ -11,7 +11,7 @@ spec:
   pipeline:
     - step: patch-and-transform
       functionRef:
-        name: upbound-function-patch-and-transform
+        name: crossplane-contrib-function-patch-and-transform
       input:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -48,3 +48,6 @@ spec:
     - configuration: xpkg.upbound.io/upbound/configuration-gitops-flux
       # renovate: datasource=github-releases depName=upbound/configuration-gitops-flux
       version: "v0.2.0"
+    - function: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
+      # renovate: datasource=github-releases depName=crossplane-contrib/function-patch-and-transform
+      version: "v0.2.1"

--- a/examples/functions.yaml
+++ b/examples/functions.yaml
@@ -1,6 +1,6 @@
 apiVersion: pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
-  name: upbound-function-patch-and-transform
+  name: crossplane-contrib-function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/upbound/function-patch-and-transform:v0.2.1
+  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.2.1


### PR DESCRIPTION
### Description of your changes
The Upbound fork of function-patch-and-transform has been retired. This PR moves the composition to the crossplane-contrib repository

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested
- [x] Run `make render` to confirm the composition renders correctly
